### PR TITLE
Semantic encoding UI (first iteration)

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,1 @@
+PUBLIC_ONTOLOGY_API_HOST=https://ontology.tbta.bible

--- a/package.json
+++ b/package.json
@@ -19,7 +19,10 @@
   },
   "dependencies": {
     "@sveltejs/kit": "^2.7.2",
-    "svelte": "^4.2.19"
+		"@tailwindcss/typography": "^0.5.15",
+		"daisyui": "^4.12.14",
+    "svelte": "^4.2.19",
+		"tailwindcss": "^3.4.14"
   },
   "devDependencies": {
     "@cloudflare/workers-types": "^4.20241022.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,9 +11,18 @@ importers:
       '@sveltejs/kit':
         specifier: ^2.7.2
         version: 2.7.2(@sveltejs/vite-plugin-svelte@3.1.2(svelte@4.2.19)(vite@5.4.10(@types/node@22.7.9)))(svelte@4.2.19)(vite@5.4.10(@types/node@22.7.9))
+      '@tailwindcss/typography':
+        specifier: ^0.5.15
+        version: 0.5.15(tailwindcss@3.4.15)
+      daisyui:
+        specifier: ^4.12.14
+        version: 4.12.14(postcss@8.4.47)
       svelte:
         specifier: ^4.2.19
         version: 4.2.19
+      tailwindcss:
+        specifier: ^3.4.14
+        version: 3.4.15
     devDependencies:
       '@cloudflare/workers-types':
         specifier: ^4.20241022.0
@@ -26,7 +35,7 @@ importers:
         version: 1.48.1
       '@stylistic/eslint-plugin':
         specifier: ^2.9.0
-        version: 2.9.0(eslint@9.13.0)(typescript@5.6.3)
+        version: 2.9.0(eslint@9.13.0(jiti@1.21.6))(typescript@5.6.3)
       '@sveltejs/adapter-cloudflare':
         specifier: ^4.7.3
         version: 4.7.3(@sveltejs/kit@2.7.2(@sveltejs/vite-plugin-svelte@3.1.2(svelte@4.2.19)(vite@5.4.10(@types/node@22.7.9)))(svelte@4.2.19)(vite@5.4.10(@types/node@22.7.9)))(wrangler@3.37.0(@cloudflare/workers-types@4.20241022.0))
@@ -41,10 +50,10 @@ importers:
         version: 10.4.20(postcss@8.4.47)
       eslint:
         specifier: ^9.13.0
-        version: 9.13.0
+        version: 9.13.0(jiti@1.21.6)
       eslint-plugin-svelte:
         specifier: ^2.46.0
-        version: 2.46.0(eslint@9.13.0)(svelte@4.2.19)
+        version: 2.46.0(eslint@9.13.0(jiti@1.21.6))(svelte@4.2.19)
       globals:
         specifier: ^15.11.0
         version: 15.11.0
@@ -68,6 +77,10 @@ importers:
         version: 5.4.10(@types/node@22.7.9)
 
 packages:
+
+  '@alloc/quick-lru@5.2.0':
+    resolution: {integrity: sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==}
+    engines: {node: '>=10'}
 
   '@ampproject/remapping@2.3.0':
     resolution: {integrity: sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==}
@@ -484,6 +497,10 @@ packages:
     resolution: {integrity: sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==}
     engines: {node: '>= 8'}
 
+  '@pkgjs/parseargs@0.11.0':
+    resolution: {integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==}
+    engines: {node: '>=14'}
+
   '@playwright/test@1.48.1':
     resolution: {integrity: sha512-s9RtWoxkOLmRJdw3oFvhFbs9OJS0BzrLUc8Hf6l2UdCNd1rqeEyD4BhCJkvzeEoD1FsK4mirsWwGerhVmYKtZg==}
     engines: {node: '>=18'}
@@ -608,6 +625,11 @@ packages:
       svelte: ^4.0.0 || ^5.0.0-next.0
       vite: ^5.0.0
 
+  '@tailwindcss/typography@0.5.15':
+    resolution: {integrity: sha512-AqhlCXl+8grUz8uqExv5OTtgpjuVIwFTSXTrh8y9/pw6q2ek7fJ+Y8ZEVw7EB2DCcuCOtEjf9w3+J3rzts01uA==}
+    peerDependencies:
+      tailwindcss: '>=3.0.0 || insiders || >=4.0.0-alpha.20'
+
   '@types/cookie@0.6.0':
     resolution: {integrity: sha512-4Kh9a6B2bQciAhf7FSuMRRkUWecJgJu9nPnx3yzpsfXX/c50REIqpHY4C82bXP90qrLtXtkDxTZosYO3UpOwlA==}
 
@@ -683,9 +705,15 @@ packages:
     resolution: {integrity: sha512-bN798gFfQX+viw3R7yrGWRqnrN2oRkEkUjjl4JNn4E8GxxbjtG3FbrEIIY3l8/hrwUwIeCZvi4QuOTP4MErVug==}
     engines: {node: '>=12'}
 
+  any-promise@1.3.0:
+    resolution: {integrity: sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A==}
+
   anymatch@3.1.3:
     resolution: {integrity: sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==}
     engines: {node: '>= 8'}
+
+  arg@5.0.2:
+    resolution: {integrity: sha512-PYjyFOLKQ9y57JvQ6QLo8dAgNqswh8M1RMJYdQduT6xbWSgK36P/Z/v+p888pM69jMMfS8Xd8F6I1kQ/I9HUGg==}
 
   argparse@2.0.1:
     resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
@@ -737,6 +765,10 @@ packages:
     resolution: {integrity: sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==}
     engines: {node: '>=6'}
 
+  camelcase-css@2.0.1:
+    resolution: {integrity: sha512-QOSvevhslijgYwRx6Rv7zKdMF8lbRmx+uQGx2+vDc+KI/eBnsy9kit5aj23AgGu3pa4t9AgwbnXWqS+iOY+2aA==}
+    engines: {node: '>= 6'}
+
   caniuse-lite@1.0.30001669:
     resolution: {integrity: sha512-DlWzFDJqstqtIVx1zeSpIMLjunf5SmwOw0N2Ck/QSQdS8PLS4+9HrLaYei4w8BIAL7IB/UEDu889d8vhCTPA0w==}
 
@@ -765,6 +797,10 @@ packages:
   color-name@1.1.4:
     resolution: {integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==}
 
+  commander@4.1.1:
+    resolution: {integrity: sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==}
+    engines: {node: '>= 6'}
+
   concat-map@0.0.1:
     resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
 
@@ -780,6 +816,9 @@ packages:
     resolution: {integrity: sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==}
     engines: {node: '>= 8'}
 
+  css-selector-tokenizer@0.8.0:
+    resolution: {integrity: sha512-Jd6Ig3/pe62/qe5SBPTN8h8LeUg/pT4lLgtavPf7updwwHpvFzxvOQBHYj2LZDMjUnBzgvIUSjRcf6oT5HzHFg==}
+
   css-tree@2.3.1:
     resolution: {integrity: sha512-6Fv1DV/TYw//QF5IzQdqsNDjx/wc8TrMBZsqjL9eW01tWb7R7k/mq+/VXfJCl7SoD5emsJop9cOByJZfs8hYIw==}
     engines: {node: ^10 || ^12.20.0 || ^14.13.0 || >=15.0.0}
@@ -788,6 +827,14 @@ packages:
     resolution: {integrity: sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==}
     engines: {node: '>=4'}
     hasBin: true
+
+  culori@3.3.0:
+    resolution: {integrity: sha512-pHJg+jbuFsCjz9iclQBqyL3B2HLCBF71BwVNujUYEvCeQMvV97R59MNK3R2+jgJ3a1fcZgI9B3vYgz8lzr/BFQ==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+
+  daisyui@4.12.14:
+    resolution: {integrity: sha512-hA27cdBasdwd4/iEjn+aidoCrRroDuo3G5W9NDKaVCJI437Mm/3eSL/2u7MkZ0pt8a+TrYF3aT2pFVemTS3how==}
+    engines: {node: '>=16.9.0'}
 
   data-uri-to-buffer@2.0.2:
     resolution: {integrity: sha512-ND9qDTLc6diwj+Xe5cdAgVTbLVdXbtxTJRXRhli8Mowuaan+0EJOtdqJ0QCHNSSPyoXGx9HX2/VMnKeC34AChA==}
@@ -810,6 +857,12 @@ packages:
 
   devalue@5.1.1:
     resolution: {integrity: sha512-maua5KUiapvEwiEAe+XnlZ3Rh0GD+qI1J/nb9vrJc3muPXvcF/8gXYTWF76+5DAqHyDUtOIImEuo0YKE9mshVw==}
+
+  didyoumean@1.2.2:
+    resolution: {integrity: sha512-gxtyfqMg7GKyhQmb056K7M3xszy/myH8w+B4RT+QXBQsvAOdc3XymqDDPHx1BgPgsdAA5SIifona89YtRATDzw==}
+
+  dlv@1.1.3:
+    resolution: {integrity: sha512-+HlytyjlPKnIG8XuRG8WvmBP8xs8P71y+SKKS6ZXWoEgLuePxtDoUEiH7WkdePWrQ5JBpE6aoVqfZfJUQkjXwA==}
 
   eastasianwidth@0.2.0:
     resolution: {integrity: sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==}
@@ -933,6 +986,9 @@ packages:
   fast-levenshtein@2.0.6:
     resolution: {integrity: sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==}
 
+  fastparse@1.1.2:
+    resolution: {integrity: sha512-483XLLxTVIwWK3QTrMGRqUfUpoOs/0hbQrl2oz4J0pAcm3A3bu84wxTFqGqkJzewCLdME38xJLJAxBABfQT8sQ==}
+
   fastq@1.17.1:
     resolution: {integrity: sha512-sRVD3lWVIXWg6By68ZN7vho9a1pQcN/WBFaAAsDDFzlJjvoGx0P8z7V1t72grFJfJhu3YPZBuu25f7Kaw2jN1w==}
 
@@ -996,6 +1052,10 @@ packages:
 
   glob-to-regexp@0.4.1:
     resolution: {integrity: sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw==}
+
+  glob@10.4.5:
+    resolution: {integrity: sha512-7Bv8RF0k6xjo7d4A/PxYLbUCfb6c+Vpd2/mB2yRDlew7Jb5hEXiCD9ibfO7wpk8i4sevK6DFny9h7EYbM3/sHg==}
+    hasBin: true
 
   glob@11.0.0:
     resolution: {integrity: sha512-9UiX/Bl6J2yaBbxKoEBRm4Cipxgok8kQYcOPEhScPwebu2I0HoQOuYdIO6S3hLuWoZgpDpwQZMzTFxgpkyT76g==}
@@ -1069,9 +1129,16 @@ packages:
   isexe@2.0.0:
     resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
 
+  jackspeak@3.4.3:
+    resolution: {integrity: sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==}
+
   jackspeak@4.0.2:
     resolution: {integrity: sha512-bZsjR/iRjl1Nk1UkjGpAzLNfQtzuijhn2g+pbZb98HQ1Gk8vM9hfbxeMBP+M2/UUdwj0RqGG3mlvk2MsAqwvEw==}
     engines: {node: 20 || >=22}
+
+  jiti@1.21.6:
+    resolution: {integrity: sha512-2yTgeWTWzMWkHu6Jp9NKgePDaYHbntiwvYuuJLbbN9vl7DC9DvXKOB2BC3ZZ92D3cvV/aflH0osDfwpHepQ53w==}
+    hasBin: true
 
   js-yaml@4.1.0:
     resolution: {integrity: sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==}
@@ -1104,6 +1171,13 @@ packages:
     resolution: {integrity: sha512-utWOt/GHzuUxnLKxB6dk81RoOeoNeHgbrXiuGk4yyF5qlRz+iIVWu56E2fqGHFrXz0QNUhLB/8nKqvRH66JKGQ==}
     engines: {node: '>=10'}
 
+  lilconfig@3.1.2:
+    resolution: {integrity: sha512-eop+wDAvpItUys0FWkHIKeC9ybYrTGbU41U5K7+bttZZeohvnY7M9dZ5kB21GNWiFT2q1OoPTvncPCgSOVO5ow==}
+    engines: {node: '>=14'}
+
+  lines-and-columns@1.2.4:
+    resolution: {integrity: sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==}
+
   locate-character@3.0.0:
     resolution: {integrity: sha512-SW13ws7BjaeJ6p7Q6CO2nchbYEc3X3J6WrmTTDto7yMPqVSZTUyY5Tjbid+Ab8gLnATtygYtiDIJGQRRn2ZOiA==}
 
@@ -1111,8 +1185,17 @@ packages:
     resolution: {integrity: sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==}
     engines: {node: '>=10'}
 
+  lodash.castarray@4.4.0:
+    resolution: {integrity: sha512-aVx8ztPv7/2ULbArGJ2Y42bG1mEQ5mGjpdvrbJcJFU3TbYybe+QlLS4pst9zV52ymy2in1KpFPiZnAOATxD4+Q==}
+
+  lodash.isplainobject@4.0.6:
+    resolution: {integrity: sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA==}
+
   lodash.merge@4.6.2:
     resolution: {integrity: sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==}
+
+  lru-cache@10.4.3:
+    resolution: {integrity: sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==}
 
   lru-cache@11.0.1:
     resolution: {integrity: sha512-CgeuL5uom6j/ZVrg7G/+1IXqRY8JXX4Hghfy5YE0EhoYQWvndP1kufu58cmZLNIDKnRhZrXfdS9urVWx98AipQ==}
@@ -1175,6 +1258,9 @@ packages:
     resolution: {integrity: sha512-71ippSywq5Yb7/tVYyGbkBggbU8H3u5Rz56fH60jGFgr8uHwxs+aSKeqmluIVzM0m0kB7xQjKS6qPfd0b2ZoqQ==}
     hasBin: true
 
+  mz@2.7.0:
+    resolution: {integrity: sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==}
+
   nanoid@3.3.7:
     resolution: {integrity: sha512-eSRppjcPIatRIMC1U6UngP8XFcz8MQWGQdt1MTBQ7NaAmvXDfvNxbvWV3x2y6CdEUciCSsDHDQZbhYaB8QEo2g==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
@@ -1197,6 +1283,14 @@ packages:
   normalize-range@0.1.2:
     resolution: {integrity: sha512-bdok/XvKII3nUpklnV6P2hxtMNrCboOjAcyBuQnWEhO665FwrSNRxU+AqpsyvO6LgGYPspN+lu5CLtw4jPRKNA==}
     engines: {node: '>=0.10.0'}
+
+  object-assign@4.1.1:
+    resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
+    engines: {node: '>=0.10.0'}
+
+  object-hash@3.0.0:
+    resolution: {integrity: sha512-RSn9F68PjH9HqtltsSnqYC1XXoWe9Bju5+213R98cNGttag9q9yAOTzdbsqvIa7aNm5WffBZFpWYr2aWrklWAw==}
+    engines: {node: '>= 6'}
 
   optionator@0.9.4:
     resolution: {integrity: sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==}
@@ -1228,6 +1322,10 @@ packages:
   path-parse@1.0.7:
     resolution: {integrity: sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==}
 
+  path-scurry@1.11.1:
+    resolution: {integrity: sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==}
+    engines: {node: '>=16 || 14 >=14.18'}
+
   path-scurry@2.0.0:
     resolution: {integrity: sha512-ypGJsmGtdXUOeM5u93TyeIEfEhM6s+ljAhrk5vAvSx8uyY/02OvrZnA0YNGUrPXfpJMgI1ODd3nwz8Npx4O4cg==}
     engines: {node: 20 || >=22}
@@ -1249,6 +1347,14 @@ packages:
     resolution: {integrity: sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==}
     engines: {node: '>=12'}
 
+  pify@2.3.0:
+    resolution: {integrity: sha512-udgsAY+fTnvv7kI7aaxbqwWNb0AHiB0qBO89PZKPkoTmGOgdbrHDKD+0B2X4uTfJ/FT1R09r9gTsjUjNJotuog==}
+    engines: {node: '>=0.10.0'}
+
+  pirates@4.0.6:
+    resolution: {integrity: sha512-saLsH7WeYYPiD25LDuLRRY/i+6HaPYr6G1OUlN39otzkSTxKnubR9RTxS3/Kk50s1g2JTgFwWQDQyplC5/SHZg==}
+    engines: {node: '>= 6'}
+
   playwright-core@1.48.1:
     resolution: {integrity: sha512-Yw/t4VAFX/bBr1OzwCuOMZkY1Cnb4z/doAFSwf4huqAGWmf9eMNjmK7NiOljCdLmxeRYcGPPmcDgU0zOlzP0YA==}
     engines: {node: '>=18'}
@@ -1258,6 +1364,18 @@ packages:
     resolution: {integrity: sha512-j8CiHW/V6HxmbntOfyB4+T/uk08tBy6ph0MpBXwuoofkSnLmlfdYNNkFTYD6ofzzlSqLA1fwH4vwvVFvJgLN0w==}
     engines: {node: '>=18'}
     hasBin: true
+
+  postcss-import@15.1.0:
+    resolution: {integrity: sha512-hpr+J05B2FVYUAXHeK1YyI267J/dDDhMU6B6civm8hSY1jYJnBXxzKDKDswzJmtLHryrjhnDjqqp/49t8FALew==}
+    engines: {node: '>=14.0.0'}
+    peerDependencies:
+      postcss: ^8.0.0
+
+  postcss-js@4.0.1:
+    resolution: {integrity: sha512-dDLF8pEO191hJMtlHFPRa8xsizHaM82MLfNkUHdUtVEV3tgTp5oj+8qbEqYM57SLfc74KSbw//4SeJma2LRVIw==}
+    engines: {node: ^12 || ^14 || >= 16}
+    peerDependencies:
+      postcss: ^8.4.21
 
   postcss-load-config@3.1.4:
     resolution: {integrity: sha512-6DiM4E7v4coTE4uzA8U//WhtPwyhiim3eyjEMFCnUpzbrkK9wJHgKDT2mR+HbtSrd/NubVaYTOpSpjUl8NQeRg==}
@@ -1271,6 +1389,24 @@ packages:
       ts-node:
         optional: true
 
+  postcss-load-config@4.0.2:
+    resolution: {integrity: sha512-bSVhyJGL00wMVoPUzAVAnbEoWyqRxkjv64tUl427SKnPrENtq6hJwUojroMz2VB+Q1edmi4IfrAPpami5VVgMQ==}
+    engines: {node: '>= 14'}
+    peerDependencies:
+      postcss: '>=8.0.9'
+      ts-node: '>=9.0.0'
+    peerDependenciesMeta:
+      postcss:
+        optional: true
+      ts-node:
+        optional: true
+
+  postcss-nested@6.2.0:
+    resolution: {integrity: sha512-HQbt28KulC5AJzG+cZtj9kvKB93CFCdLvog1WFLf1D+xmMvPGlBstkpTEZfK5+AN9hfJocyBFCNiqyS48bpgzQ==}
+    engines: {node: '>=12.0'}
+    peerDependencies:
+      postcss: ^8.2.14
+
   postcss-safe-parser@6.0.0:
     resolution: {integrity: sha512-FARHN8pwH+WiS2OPCxJI8FuRJpTVnn6ZNFiqAM2aeW2LwTHWWmWgIyKC6cUo0L8aeKiF/14MNvnpls6R2PBeMQ==}
     engines: {node: '>=12.0'}
@@ -1282,6 +1418,10 @@ packages:
     engines: {node: '>=12.0'}
     peerDependencies:
       postcss: ^8.4.29
+
+  postcss-selector-parser@6.0.10:
+    resolution: {integrity: sha512-IQ7TZdoaqbT+LCpShg46jnZVlhWD2w6iQYAcYXfHARZ7X1t/UGhhceQDs5X0cGqKvYlHNOuv7Oa1xmb0oQuA3w==}
+    engines: {node: '>=4'}
 
   postcss-selector-parser@6.1.2:
     resolution: {integrity: sha512-Q8qQfPiZ+THO/3ZrOrO0cJJKfpYCagtMUkXbnEfmgUjwXg6z/WBeOyS9APBBPCTSiDV+s4SwQGu8yFsiMRIudg==}
@@ -1307,6 +1447,9 @@ packages:
 
   queue-microtask@1.2.3:
     resolution: {integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==}
+
+  read-cache@1.0.0:
+    resolution: {integrity: sha512-Owdv/Ft7IjOgm/i0xvNDZ1LrRANRfew4b2prF3OWMQLxLfu3bS8FVhCsrSCMK4lR56Y9ya+AThoTpDCTxCmpRA==}
 
   readdirp@3.6.0:
     resolution: {integrity: sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==}
@@ -1430,6 +1573,11 @@ packages:
     resolution: {integrity: sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==}
     engines: {node: '>=8'}
 
+  sucrase@3.35.0:
+    resolution: {integrity: sha512-8EbVDiu9iN/nESwxeSxDKe0dunta1GOlHufmSSXxMD2z2/tMZpDMpvXQGsc+ajGo8y2uYUmixaSRUc/QPoQ0GA==}
+    engines: {node: '>=16 || 14 >=14.17'}
+    hasBin: true
+
   supports-color@7.2.0:
     resolution: {integrity: sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==}
     engines: {node: '>=8'}
@@ -1465,8 +1613,20 @@ packages:
     resolution: {integrity: sha512-IY1rnGr6izd10B0A8LqsBfmlT5OILVuZ7XsI0vdGPEvuonFV7NYEUK4dAkm9Zg2q0Um92kYjTpS1CAP3Nh/KWw==}
     engines: {node: '>=16'}
 
+  tailwindcss@3.4.15:
+    resolution: {integrity: sha512-r4MeXnfBmSOuKUWmXe6h2CcyfzJCEk4F0pptO5jlnYSIViUkVmsawj80N5h2lO3gwcmSb4n3PuN+e+GC1Guylw==}
+    engines: {node: '>=14.0.0'}
+    hasBin: true
+
   text-table@0.2.0:
     resolution: {integrity: sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==}
+
+  thenify-all@1.6.0:
+    resolution: {integrity: sha512-RNxQH/qI8/t3thXJDwcstUO4zeqo64+Uy/+sNVRBx4Xn2OX+OZ9oP+iJnNFqplFra2ZUVeKCSa2oVWi3T4uVmA==}
+    engines: {node: '>=0.8'}
+
+  thenify@3.3.1:
+    resolution: {integrity: sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw==}
 
   tiny-glob@0.2.9:
     resolution: {integrity: sha512-g/55ssRPUjShh+xkfx9UPDXqhckHEsHr4Vd9zX55oSdGZc/MD0m3sferOkwWtp98bv+kcVfEHtRJgBVJzelrzg==}
@@ -1484,6 +1644,9 @@ packages:
     engines: {node: '>=16'}
     peerDependencies:
       typescript: '>=4.2.0'
+
+  ts-interface-checker@0.1.13:
+    resolution: {integrity: sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==}
 
   tslib@2.8.0:
     resolution: {integrity: sha512-jWVzBLplnCmoaTr13V9dYbiQ99wvZRd0vNWaDRg+aVYRcjDF3nDksxFDE/+fkXnKhpnUUkmx5pK/v8mCtLVqZA==}
@@ -1610,6 +1773,11 @@ packages:
     resolution: {integrity: sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==}
     engines: {node: '>= 6'}
 
+  yaml@2.6.1:
+    resolution: {integrity: sha512-7r0XPzioN/Q9kXBro/XPnA6kznR73DHq+GXh5ON7ZozRO6aMjbmiBuKste2wslTFkC5d1dw0GooOCepZXJ2SAg==}
+    engines: {node: '>= 14'}
+    hasBin: true
+
   yocto-queue@0.1.0:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
     engines: {node: '>=10'}
@@ -1621,6 +1789,8 @@ packages:
     resolution: {integrity: sha512-XBx9AXhXktjUqnepgTiE5flcKIYWi/rme0Eaj+5Y0lftuGBq+jyRu/md4WnuxqgP1ubdpNCsYEYPxrzVHD8d6g==}
 
 snapshots:
+
+  '@alloc/quick-lru@5.2.0': {}
 
   '@ampproject/remapping@2.3.0':
     dependencies:
@@ -1797,9 +1967,9 @@ snapshots:
   '@esbuild/win32-x64@0.21.5':
     optional: true
 
-  '@eslint-community/eslint-utils@4.4.0(eslint@9.13.0)':
+  '@eslint-community/eslint-utils@4.4.0(eslint@9.13.0(jiti@1.21.6))':
     dependencies:
-      eslint: 9.13.0
+      eslint: 9.13.0(jiti@1.21.6)
       eslint-visitor-keys: 3.4.3
 
   '@eslint-community/regexpp@4.11.1': {}
@@ -1892,6 +2062,9 @@ snapshots:
       '@nodelib/fs.scandir': 2.1.5
       fastq: 1.17.1
 
+  '@pkgjs/parseargs@0.11.0':
+    optional: true
+
   '@playwright/test@1.48.1':
     dependencies:
       playwright: 1.48.1
@@ -1946,10 +2119,10 @@ snapshots:
   '@rollup/rollup-win32-x64-msvc@4.24.0':
     optional: true
 
-  '@stylistic/eslint-plugin@2.9.0(eslint@9.13.0)(typescript@5.6.3)':
+  '@stylistic/eslint-plugin@2.9.0(eslint@9.13.0(jiti@1.21.6))(typescript@5.6.3)':
     dependencies:
-      '@typescript-eslint/utils': 8.11.0(eslint@9.13.0)(typescript@5.6.3)
-      eslint: 9.13.0
+      '@typescript-eslint/utils': 8.11.0(eslint@9.13.0(jiti@1.21.6))(typescript@5.6.3)
+      eslint: 9.13.0(jiti@1.21.6)
       eslint-visitor-keys: 4.1.0
       espree: 10.2.0
       estraverse: 5.3.0
@@ -2007,6 +2180,14 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@tailwindcss/typography@0.5.15(tailwindcss@3.4.15)':
+    dependencies:
+      lodash.castarray: 4.4.0
+      lodash.isplainobject: 4.0.6
+      lodash.merge: 4.6.2
+      postcss-selector-parser: 6.0.10
+      tailwindcss: 3.4.15
+
   '@types/cookie@0.6.0': {}
 
   '@types/estree@1.0.6': {}
@@ -2043,13 +2224,13 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/utils@8.11.0(eslint@9.13.0)(typescript@5.6.3)':
+  '@typescript-eslint/utils@8.11.0(eslint@9.13.0(jiti@1.21.6))(typescript@5.6.3)':
     dependencies:
-      '@eslint-community/eslint-utils': 4.4.0(eslint@9.13.0)
+      '@eslint-community/eslint-utils': 4.4.0(eslint@9.13.0(jiti@1.21.6))
       '@typescript-eslint/scope-manager': 8.11.0
       '@typescript-eslint/types': 8.11.0
       '@typescript-eslint/typescript-estree': 8.11.0(typescript@5.6.3)
-      eslint: 9.13.0
+      eslint: 9.13.0(jiti@1.21.6)
     transitivePeerDependencies:
       - supports-color
       - typescript
@@ -2086,10 +2267,14 @@ snapshots:
 
   ansi-styles@6.2.1: {}
 
+  any-promise@1.3.0: {}
+
   anymatch@3.1.3:
     dependencies:
       normalize-path: 3.0.0
       picomatch: 2.3.1
+
+  arg@5.0.2: {}
 
   argparse@2.0.1: {}
 
@@ -2139,6 +2324,8 @@ snapshots:
 
   callsites@3.1.0: {}
 
+  camelcase-css@2.0.1: {}
+
   caniuse-lite@1.0.30001669: {}
 
   capnp-ts@0.7.0:
@@ -2183,6 +2370,8 @@ snapshots:
 
   color-name@1.1.4: {}
 
+  commander@4.1.1: {}
+
   concat-map@0.0.1: {}
 
   cookie@0.6.0: {}
@@ -2195,12 +2384,28 @@ snapshots:
       shebang-command: 2.0.0
       which: 2.0.2
 
+  css-selector-tokenizer@0.8.0:
+    dependencies:
+      cssesc: 3.0.0
+      fastparse: 1.1.2
+
   css-tree@2.3.1:
     dependencies:
       mdn-data: 2.0.30
       source-map-js: 1.2.1
 
   cssesc@3.0.0: {}
+
+  culori@3.3.0: {}
+
+  daisyui@4.12.14(postcss@8.4.47):
+    dependencies:
+      css-selector-tokenizer: 0.8.0
+      culori: 3.3.0
+      picocolors: 1.1.1
+      postcss-js: 4.0.1(postcss@8.4.47)
+    transitivePeerDependencies:
+      - postcss
 
   data-uri-to-buffer@2.0.2: {}
 
@@ -2213,6 +2418,10 @@ snapshots:
   deepmerge@4.3.1: {}
 
   devalue@5.1.1: {}
+
+  didyoumean@1.2.2: {}
+
+  dlv@1.1.3: {}
 
   eastasianwidth@0.2.0: {}
 
@@ -2277,17 +2486,17 @@ snapshots:
 
   escape-string-regexp@4.0.0: {}
 
-  eslint-compat-utils@0.5.1(eslint@9.13.0):
+  eslint-compat-utils@0.5.1(eslint@9.13.0(jiti@1.21.6)):
     dependencies:
-      eslint: 9.13.0
+      eslint: 9.13.0(jiti@1.21.6)
       semver: 7.6.3
 
-  eslint-plugin-svelte@2.46.0(eslint@9.13.0)(svelte@4.2.19):
+  eslint-plugin-svelte@2.46.0(eslint@9.13.0(jiti@1.21.6))(svelte@4.2.19):
     dependencies:
-      '@eslint-community/eslint-utils': 4.4.0(eslint@9.13.0)
+      '@eslint-community/eslint-utils': 4.4.0(eslint@9.13.0(jiti@1.21.6))
       '@jridgewell/sourcemap-codec': 1.5.0
-      eslint: 9.13.0
-      eslint-compat-utils: 0.5.1(eslint@9.13.0)
+      eslint: 9.13.0(jiti@1.21.6)
+      eslint-compat-utils: 0.5.1(eslint@9.13.0(jiti@1.21.6))
       esutils: 2.0.3
       known-css-properties: 0.35.0
       postcss: 8.4.47
@@ -2315,9 +2524,9 @@ snapshots:
 
   eslint-visitor-keys@4.1.0: {}
 
-  eslint@9.13.0:
+  eslint@9.13.0(jiti@1.21.6):
     dependencies:
-      '@eslint-community/eslint-utils': 4.4.0(eslint@9.13.0)
+      '@eslint-community/eslint-utils': 4.4.0(eslint@9.13.0(jiti@1.21.6))
       '@eslint-community/regexpp': 4.11.1
       '@eslint/config-array': 0.18.0
       '@eslint/core': 0.7.0
@@ -2352,6 +2561,8 @@ snapshots:
       natural-compare: 1.4.0
       optionator: 0.9.4
       text-table: 0.2.0
+    optionalDependencies:
+      jiti: 1.21.6
     transitivePeerDependencies:
       - supports-color
 
@@ -2402,6 +2613,8 @@ snapshots:
   fast-json-stable-stringify@2.1.0: {}
 
   fast-levenshtein@2.0.6: {}
+
+  fastparse@1.1.2: {}
 
   fastq@1.17.1:
     dependencies:
@@ -2461,6 +2674,15 @@ snapshots:
 
   glob-to-regexp@0.4.1: {}
 
+  glob@10.4.5:
+    dependencies:
+      foreground-child: 3.3.0
+      jackspeak: 3.4.3
+      minimatch: 9.0.5
+      minipass: 7.1.2
+      package-json-from-dist: 1.0.1
+      path-scurry: 1.11.1
+
   glob@11.0.0:
     dependencies:
       foreground-child: 3.3.0
@@ -2519,9 +2741,17 @@ snapshots:
 
   isexe@2.0.0: {}
 
+  jackspeak@3.4.3:
+    dependencies:
+      '@isaacs/cliui': 8.0.2
+    optionalDependencies:
+      '@pkgjs/parseargs': 0.11.0
+
   jackspeak@4.0.2:
     dependencies:
       '@isaacs/cliui': 8.0.2
+
+  jiti@1.21.6: {}
 
   js-yaml@4.1.0:
     dependencies:
@@ -2548,13 +2778,23 @@ snapshots:
 
   lilconfig@2.1.0: {}
 
+  lilconfig@3.1.2: {}
+
+  lines-and-columns@1.2.4: {}
+
   locate-character@3.0.0: {}
 
   locate-path@6.0.0:
     dependencies:
       p-locate: 5.0.0
 
+  lodash.castarray@4.4.0: {}
+
+  lodash.isplainobject@4.0.6: {}
+
   lodash.merge@4.6.2: {}
+
+  lru-cache@10.4.3: {}
 
   lru-cache@11.0.1: {}
 
@@ -2618,6 +2858,12 @@ snapshots:
 
   mustache@4.2.0: {}
 
+  mz@2.7.0:
+    dependencies:
+      any-promise: 1.3.0
+      object-assign: 4.1.1
+      thenify-all: 1.6.0
+
   nanoid@3.3.7: {}
 
   natural-compare@1.4.0: {}
@@ -2629,6 +2875,10 @@ snapshots:
   normalize-path@3.0.0: {}
 
   normalize-range@0.1.2: {}
+
+  object-assign@4.1.1: {}
+
+  object-hash@3.0.0: {}
 
   optionator@0.9.4:
     dependencies:
@@ -2659,6 +2909,11 @@ snapshots:
 
   path-parse@1.0.7: {}
 
+  path-scurry@1.11.1:
+    dependencies:
+      lru-cache: 10.4.3
+      minipass: 7.1.2
+
   path-scurry@2.0.0:
     dependencies:
       lru-cache: 11.0.1
@@ -2678,6 +2933,10 @@ snapshots:
 
   picomatch@4.0.2: {}
 
+  pify@2.3.0: {}
+
+  pirates@4.0.6: {}
+
   playwright-core@1.48.1: {}
 
   playwright@1.48.1:
@@ -2686,12 +2945,36 @@ snapshots:
     optionalDependencies:
       fsevents: 2.3.2
 
+  postcss-import@15.1.0(postcss@8.4.47):
+    dependencies:
+      postcss: 8.4.47
+      postcss-value-parser: 4.2.0
+      read-cache: 1.0.0
+      resolve: 1.22.8
+
+  postcss-js@4.0.1(postcss@8.4.47):
+    dependencies:
+      camelcase-css: 2.0.1
+      postcss: 8.4.47
+
   postcss-load-config@3.1.4(postcss@8.4.47):
     dependencies:
       lilconfig: 2.1.0
       yaml: 1.10.2
     optionalDependencies:
       postcss: 8.4.47
+
+  postcss-load-config@4.0.2(postcss@8.4.47):
+    dependencies:
+      lilconfig: 3.1.2
+      yaml: 2.6.1
+    optionalDependencies:
+      postcss: 8.4.47
+
+  postcss-nested@6.2.0(postcss@8.4.47):
+    dependencies:
+      postcss: 8.4.47
+      postcss-selector-parser: 6.1.2
 
   postcss-safe-parser@6.0.0(postcss@8.4.47):
     dependencies:
@@ -2700,6 +2983,11 @@ snapshots:
   postcss-scss@4.0.9(postcss@8.4.47):
     dependencies:
       postcss: 8.4.47
+
+  postcss-selector-parser@6.0.10:
+    dependencies:
+      cssesc: 3.0.0
+      util-deprecate: 1.0.2
 
   postcss-selector-parser@6.1.2:
     dependencies:
@@ -2721,6 +3009,10 @@ snapshots:
   punycode@2.3.1: {}
 
   queue-microtask@1.2.3: {}
+
+  read-cache@1.0.0:
+    dependencies:
+      pify: 2.3.0
 
   readdirp@3.6.0:
     dependencies:
@@ -2849,6 +3141,16 @@ snapshots:
 
   strip-json-comments@3.1.1: {}
 
+  sucrase@3.35.0:
+    dependencies:
+      '@jridgewell/gen-mapping': 0.3.5
+      commander: 4.1.1
+      glob: 10.4.5
+      lines-and-columns: 1.2.4
+      mz: 2.7.0
+      pirates: 4.0.6
+      ts-interface-checker: 0.1.13
+
   supports-color@7.2.0:
     dependencies:
       has-flag: 4.0.0
@@ -2898,7 +3200,42 @@ snapshots:
       magic-string: 0.30.12
       periscopic: 3.1.0
 
+  tailwindcss@3.4.15:
+    dependencies:
+      '@alloc/quick-lru': 5.2.0
+      arg: 5.0.2
+      chokidar: 3.6.0
+      didyoumean: 1.2.2
+      dlv: 1.1.3
+      fast-glob: 3.3.2
+      glob-parent: 6.0.2
+      is-glob: 4.0.3
+      jiti: 1.21.6
+      lilconfig: 2.1.0
+      micromatch: 4.0.8
+      normalize-path: 3.0.0
+      object-hash: 3.0.0
+      picocolors: 1.1.1
+      postcss: 8.4.47
+      postcss-import: 15.1.0(postcss@8.4.47)
+      postcss-js: 4.0.1(postcss@8.4.47)
+      postcss-load-config: 4.0.2(postcss@8.4.47)
+      postcss-nested: 6.2.0(postcss@8.4.47)
+      postcss-selector-parser: 6.1.2
+      resolve: 1.22.8
+      sucrase: 3.35.0
+    transitivePeerDependencies:
+      - ts-node
+
   text-table@0.2.0: {}
+
+  thenify-all@1.6.0:
+    dependencies:
+      thenify: 3.3.1
+
+  thenify@3.3.1:
+    dependencies:
+      any-promise: 1.3.0
 
   tiny-glob@0.2.9:
     dependencies:
@@ -2914,6 +3251,8 @@ snapshots:
   ts-api-utils@1.3.0(typescript@5.6.3):
     dependencies:
       typescript: 5.6.3
+
+  ts-interface-checker@0.1.13: {}
 
   tslib@2.8.0: {}
 
@@ -3014,6 +3353,8 @@ snapshots:
   xxhash-wasm@1.0.2: {}
 
   yaml@1.10.2: {}
+
+  yaml@2.6.1: {}
 
   yocto-queue@0.1.0: {}
 

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,5 +1,6 @@
 export default {
 	plugins: {
+		tailwindcss: {},
 		autoprefixer: {},
 	},
 }

--- a/src/lib/Brand.svelte
+++ b/src/lib/Brand.svelte
@@ -1,0 +1,6 @@
+
+<div class="prose">
+	<h1 class="mb-4 hidden md:block">
+		Sources <sup class="relative -top-6 end-16 text-sm text-neutral-500">TaBiThA</sup>
+	</h1>
+</div>

--- a/src/lib/app.postcss
+++ b/src/lib/app.postcss
@@ -1,0 +1,55 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+/* https://tailwindcss.com/docs/container */
+body {
+	/* stacked layout with sticky footer */
+	@apply grid h-screen grid-rows-[auto_1fr_auto];
+}
+
+/* TODO: third copy of these, time to DRY them out.  Also used in Ontology and Editor apps.
+
+	complexity level colors in TBTA are as follows:
+	0 => blue
+	1 => creme
+	2 => magenta
+	3 => green
+	4 => brown
+*/
+.L0 {
+	color: whitesmoke;
+	background-color: #0b66ff;
+}
+.L1 {
+	color: darkblue;
+	background-color: #fcffc5;
+	filter: saturate(200%);
+}
+.L2 {
+	color: yellow;
+	background-color: #fb00ff;
+}
+.L3 {
+	color: whitesmoke;
+	background-color: #0f7000;
+}
+.L4 {
+	color: whitesmoke;
+	background-color: #6b2f30;
+}
+.L0-text {
+	color: whitesmoke;
+}
+.L1-text {
+	color: darkblue;
+}
+.L2-text {
+	color: yellow;
+}
+.L3-text {
+	color: whitesmoke;
+}
+.L4-text {
+	color: whitesmoke;
+}

--- a/src/lib/encoding/index.d.ts
+++ b/src/lib/encoding/index.d.ts
@@ -1,0 +1,43 @@
+type Reference = {
+	type: string
+	id_primary: string
+	id_secondary: string
+	id_tertiary: string
+}
+
+type SourceEntity = {
+	category: CategoryName
+	value: string
+} & SourceFeatures & SourceOntologyData
+
+type SourceFeatures = {
+	feature_codes: string
+	features: EntityFeature[]
+}
+
+type SourceOntologyData = {
+	ontology_result: OntologyResult|null
+	complex_pairing: OntologyResult|null
+}
+
+type EntityFilter = (entity: SourceEntity) => boolean
+
+type CategoryName = string
+type FeatureName = string
+type FeatureValue = string
+
+type EntityFeature = {
+	name: FeatureName,
+	value: FeatureValue,
+}
+
+type OntologyResult = {
+	stem: string
+	sense: string
+	part_of_speech: string
+	level: string
+	gloss: string
+	// TODO include more info?
+	// brief_gloss: string
+	// categorization: string[]
+}

--- a/src/lib/encoding/index.d.ts
+++ b/src/lib/encoding/index.d.ts
@@ -1,23 +1,22 @@
-type Reference = {
-	type: string
-	id_primary: string
-	id_secondary: string
-	id_tertiary: string
-}
-
 type SourceEntity = {
 	category: CategoryName
 	value: string
-} & SourceFeatures & SourceOntologyData
+} & SourceFeatures & SourceConceptData
 
 type SourceFeatures = {
 	feature_codes: string
 	features: EntityFeature[]
 }
 
-type SourceOntologyData = {
-	ontology_result: OntologyResult|null
-	complex_pairing: OntologyResult|null
+type SourceConceptData = {
+	concept: SourceConcept|null
+	pairing_concept: SourceConcept|null
+}
+
+type SourceConcept = {
+	stem: string
+	sense: string
+	part_of_speech: string
 }
 
 type EntityFilter = (entity: SourceEntity) => boolean

--- a/src/lib/encoding/index.d.ts
+++ b/src/lib/encoding/index.d.ts
@@ -26,6 +26,14 @@ type CategoryName = string
 type FeatureName = string
 type FeatureValue = string
 
+type DbFeature = {
+	category: CategoryName
+	position: Number
+	code: string
+	feature: FeatureName
+	value: FeatureValue
+}
+
 type EntityFeature = {
 	name: FeatureName,
 	value: FeatureValue,

--- a/src/lib/encoding/index.d.ts
+++ b/src/lib/encoding/index.d.ts
@@ -1,5 +1,6 @@
 type SourceEntity = {
 	category: CategoryName
+	category_abbr: string
 	value: string
 } & SourceFeatures & SourceConceptData
 

--- a/src/lib/encoding/semantic_encoding.ts
+++ b/src/lib/encoding/semantic_encoding.ts
@@ -1,0 +1,159 @@
+import { PUBLIC_ONTOLOGY_API_HOST } from '$env/static/public'
+import type { D1Database } from '@cloudflare/workers-types'
+
+const CATEGORY_NAME_LOOKUP = new Map([
+	['N', 'Noun'],
+	['V', 'Verb'],
+	['A', 'Adjective'],
+	['a', 'Adverb'],
+	['P', 'Adposition'],
+	['C', 'Conjunction'],
+	['p', 'Phrasal'],
+	['r', 'Particle'],
+	['n', 'Noun Phrase'],
+	['v', 'Verb Phrase'],
+	['j', 'Adjective Phrase'],
+	['d', 'Adverb Phrase'],
+	['c', 'Clause'],
+	['R', 'Paragraph'],
+	['E', 'Section'],
+	['.', 'period'],
+])
+
+const WORD_ENTITY_CATEGORIES = new Set(['Noun', 'Verb', 'Adjective', 'Adverb', 'Adposition', 'Conjunction', 'Phrasal', 'Particle'])
+
+/**
+ * The phase_2_encoding looks something like:
+ * ~\wd ~\tg c-IDp00NNNNNNNNNNNNN.............~\lu {~\wd ~\tg C-1A.....~\lu then~\wd ~\tg n-SAN.N........~\lu (...
+ *
+ * If present, the first character of the features indicates the 'entity' type.
+ * This could be a clause/phrase boundary, part of speech, or even certain punctuation.
+ *
+ * '{' and '}' indicate a main clause boundary
+ * '[' and ']' indicate a subordinate clause boundary
+ * '(' and ')' indicate a phrase boundary
+ *
+ * Examples:
+ * ~\wd ~\tg c-IDp00NNNNNNNNNNNNN.............~\lu {    => { type: 'c', label: 'Clause', features: 'IDp00NNNNNNNNNNNNN.............', value: '{' }
+ * ~\wd ~\tg N-1A1SDAnK3NN........~\lu God  => { type: 'N', label: 'Noun', features: '1A1SDAnK3NN........', value: 'God' }
+ * ~\wd ~\tg v-S.....~\lu (     => { type: 'v', label: 'VP', features: 'S.....', value: '(' }
+ * ~\wd ~\tg C-1A.....~\lu then => { type: 'C', label: 'Conjunction', features: '1A.....', value: 'then' }
+ * ~\wd ~\tg ~\lu )             => { type: '', label: '', features: '', value: ')' }
+ * ~\wd ~\tg .-~\lu .           => { type: '.', label: 'period', features: '', value: '.' }
+ * ~\\wd ~\\tg R-~\\lu |        => { type: 'R', label: 'Paragraph', features: '', value: '|' }
+ */
+export async function transform_semantic_encoding(semantic_encoding: string, db: D1Database): Promise<SourceEntity[]> {
+	const EXTRACT_TYPE_FEATURES_VALUES = /~\\wd ~\\tg (?:([\w.])-([^~]*))?~\\lu ([^~]+)/g
+	const entities = [...semantic_encoding.matchAll(EXTRACT_TYPE_FEATURES_VALUES)]
+
+	return await Promise.all(entities.map(decode_entity))
+
+	// ['~\wd ~\tg N-1A1SDAnK3NN........~\lu God', 'N', '1A1SDAnK3NN........', 'God']
+	async function decode_entity(entity_match: RegExpMatchArray): Promise<SourceEntity> {
+		const category_code = entity_match[1] ?? ''
+		const feature_codes = entity_match[2] ?? ''
+		const value = entity_match[3]
+
+		const category = CATEGORY_NAME_LOOKUP.get(category_code) || ''
+		const features = await transform_features(feature_codes, category_code, db)
+		const ontology_data = await get_ontology_data(value, category, feature_codes)
+
+		return {
+			category,
+			value,
+			...features,
+			...ontology_data,
+		}
+	}
+}
+
+async function transform_features(feature_codes: string, category_code: string, db: D1Database): Promise<SourceFeatures> {
+	if (!feature_codes.length) {
+		return { feature_codes, features: [] }
+	}
+
+	const category = CATEGORY_NAME_LOOKUP.get(category_code) ?? ''
+
+	if (WORD_ENTITY_CATEGORIES.has(category)) {
+		// The first feature is the semantic complexity level, which is set during generation.
+		// It is therefore meaningless at this stage and can be dropped.
+
+		// The second feature is the lexical sense, which is treated specially elsewhere.
+		// So it too can be dropped from the features.
+
+		feature_codes = feature_codes.slice(2)
+	}
+
+	// The first feature on a Noun is the Noun List Index, and its value is just the character itself.
+	// This feature is not included in the 'Features' database, and so needs to be handled separately.
+	const is_noun = category === 'Noun'
+
+	const features = await Promise.all(
+		Array.from(feature_codes).map((feature_code, index) => get_feature_value(category, is_noun ? index - 1 : index, feature_code, db))
+	)
+	
+	if (is_noun) {
+		// at this point, entity_features[0] is an empty value
+		features[0] = { name: 'Noun List Index', value: feature_codes[0] }
+	}
+
+	return {
+		feature_codes,
+		features,
+	}
+}
+
+async function get_feature_value(category: CategoryName, position: number, feature_code: string, db: D1Database): Promise<EntityFeature> {
+	const sql = `
+		SELECT feature AS name, value
+		FROM Features
+		WHERE category = ? AND position = ? AND code = ?
+	`
+
+	// Add 1 to position because the position in the db is not zero-based like an index
+	const result = await db.prepare(sql).bind(category, position + 1, feature_code).first<EntityFeature>()
+
+	return result ?? { name: '', value: '' }
+}
+
+async function get_ontology_data(value: string, category: string, feature_codes: string): Promise<SourceOntologyData> {
+	if (!WORD_ENTITY_CATEGORIES.has(category)) {
+		return { ontology_result: null, complex_pairing: null }
+	}
+
+	const sense = feature_codes[1]
+
+	// follower/Adisciple -> follower / disciple-A
+	const EXTRACT_PAIRING = /^([^/]+)\/([A-Z])(.+)$/
+	const match = value.match(EXTRACT_PAIRING)
+	if (match) {
+		const [, stem, pairing_sense, pairing_stem] = match
+		return {
+			ontology_result: await fetch_ontology_data(category, stem, sense),
+			complex_pairing: await fetch_ontology_data(category, pairing_stem, pairing_sense),
+		}
+	}
+
+	return {
+		ontology_result: await fetch_ontology_data(category, value, sense),
+		complex_pairing: null,
+	}
+}
+
+async function fetch_ontology_data(category: string, stem: string, sense: string): Promise<OntologyResult> {
+	const response = await fetch(`${PUBLIC_ONTOLOGY_API_HOST}/search?q=${stem}-${sense}&category=${category}`)
+
+	const DEFAULT_DATA = {
+		stem,
+		sense,
+		part_of_speech: category,
+		level: '',
+		gloss: '',
+	}
+
+	if (!response.ok) {
+		return DEFAULT_DATA
+	}
+
+	return (await response.json())[0] ?? DEFAULT_DATA
+}

--- a/src/lib/encoding/semantic_encoding.ts
+++ b/src/lib/encoding/semantic_encoding.ts
@@ -75,7 +75,7 @@ export async function transform_semantic_encoding(semantic_encoding: string, db:
 		const category = CATEGORY_NAME_LOOKUP.get(category_code) || ''
 		const category_abbr = CATEGORY_ABBREVIATIONS.get(category) || ''
 		const features = await transform_features(feature_codes, category_code, db)
-		const ontology_data = await get_concept_data(value, category, feature_codes)
+		const ontology_data = get_concept_data(value, category, feature_codes)
 
 		return {
 			category,
@@ -136,7 +136,7 @@ async function get_feature_value(category: CategoryName, position: number, featu
 	return result ?? { name: '', value: '' }
 }
 
-async function get_concept_data(value: string, category: string, feature_codes: string): Promise<SourceConceptData> {
+function get_concept_data(value: string, category: string, feature_codes: string): SourceConceptData {
 	if (!WORD_ENTITY_CATEGORIES.has(category)) {
 		return { concept: null, pairing_concept: null }
 	}

--- a/src/lib/encoding/semantic_encoding.ts
+++ b/src/lib/encoding/semantic_encoding.ts
@@ -1,4 +1,3 @@
-import { PUBLIC_ONTOLOGY_API_HOST } from '$env/static/public'
 import type { D1Database } from '@cloudflare/workers-types'
 
 const CATEGORY_NAME_LOOKUP = new Map([
@@ -18,6 +17,25 @@ const CATEGORY_NAME_LOOKUP = new Map([
 	['R', 'Paragraph'],
 	['E', 'Section'],
 	['.', 'period'],
+])
+
+const CATEGORY_ABBREVIATIONS = new Map([
+	['Noun', 'N'],
+	['Verb', 'V'],
+	['Adjective', 'Adj'],
+	['Adverb', 'Adv'],
+	['Adposition', 'Adp'],
+	['Conjunction', 'Con'],
+	['Phrasal', 'Phr'],
+	['Particle', 'Par'],
+	['Noun Phrase', 'NP'],
+	['Verb Phrase', 'VP'],
+	['Adjective Phrase', 'AdjP'],
+	['Adverb Phrase', 'AdvP'],
+	['Clause', 'C'],
+	['Paragraph', 'R'],
+	['Section', 'E'],
+	['period', 'period'],
 ])
 
 const WORD_ENTITY_CATEGORIES = new Set(['Noun', 'Verb', 'Adjective', 'Adverb', 'Adposition', 'Conjunction', 'Phrasal', 'Particle'])
@@ -55,11 +73,13 @@ export async function transform_semantic_encoding(semantic_encoding: string, db:
 		const value = entity_match[3]
 
 		const category = CATEGORY_NAME_LOOKUP.get(category_code) || ''
+		const category_abbr = CATEGORY_ABBREVIATIONS.get(category) || ''
 		const features = await transform_features(feature_codes, category_code, db)
 		const ontology_data = await get_concept_data(value, category, feature_codes)
 
 		return {
 			category,
+			category_abbr,
 			value,
 			...features,
 			...ontology_data,

--- a/src/lib/entity_displays/BoundaryEnd.svelte
+++ b/src/lib/entity_displays/BoundaryEnd.svelte
@@ -1,0 +1,10 @@
+<script>
+	import Punctuation from './Punctuation.svelte'
+
+	/** @type {SourceEntity} */
+	export let source_entity
+
+	// TODO change character and size based on boundary type
+</script>
+
+<Punctuation {source_entity} />

--- a/src/lib/entity_displays/BoundaryStart.svelte
+++ b/src/lib/entity_displays/BoundaryStart.svelte
@@ -8,7 +8,7 @@
 	// TODO change character and size based on boundary type
 </script>
 
-<span class="inline-flex border-solid border-base-content px-3 py-6 text-lg tracking-widest">
+<span class="inline-flex border-solid border-base-content pe-1 py-2 text-lg tracking-widest">
 	<Punctuation {source_entity} />
 	<Features {source_entity} classes={'self-center'} />
 </span>

--- a/src/lib/entity_displays/BoundaryStart.svelte
+++ b/src/lib/entity_displays/BoundaryStart.svelte
@@ -1,0 +1,14 @@
+<script>
+	import Features from './Features.svelte'
+	import Punctuation from './Punctuation.svelte'
+
+	/** @type {SourceEntity} */
+	export let source_entity
+
+	// TODO change character and size based on boundary type
+</script>
+
+<span class="inline-flex border-solid border-base-content px-3 py-6 text-lg tracking-widest">
+	<Punctuation {source_entity} />
+	<Features {source_entity} classes={'self-center'} />
+</span>

--- a/src/lib/entity_displays/Concept.svelte
+++ b/src/lib/entity_displays/Concept.svelte
@@ -3,18 +3,18 @@
 	import OntologyResult from './OntologyResult.svelte'
 
 	export let source_entity: SourceEntity
-	const ontology_data = source_entity.ontology_result!	// will always be non-null at this point
+	const concept = source_entity.concept!	// will always be non-null at this point
 </script>
 
-<span class="inline-flex border-solid border-base-content px-3 py-6 text-lg tracking-normal">
+<span class="inline-flex border-solid border-base-content px-1 py-2 text-lg tracking-normal">
 	<table>
 		<tr>
 			<td>
-				<OntologyResult data={ontology_data} />
+				<OntologyResult data={concept} />
 			</td>
-			{#if source_entity.complex_pairing !== null}
+			{#if source_entity.pairing_concept !== null}
 				<td>/</td>
-				<td><OntologyResult data={source_entity.complex_pairing} /></td>
+				<td><OntologyResult data={source_entity.pairing_concept} /></td>
 			{/if}
 		</tr>
 		<tr><td>

--- a/src/lib/entity_displays/Concept.svelte
+++ b/src/lib/entity_displays/Concept.svelte
@@ -1,0 +1,24 @@
+<script lang="ts">
+	import Features from './Features.svelte'
+	import OntologyResult from './OntologyResult.svelte'
+
+	export let source_entity: SourceEntity
+	const ontology_data = source_entity.ontology_result!	// will always be non-null at this point
+</script>
+
+<span class="inline-flex border-solid border-base-content px-3 py-6 text-lg tracking-normal">
+	<table>
+		<tr>
+			<td>
+				<OntologyResult data={ontology_data} />
+			</td>
+			{#if source_entity.complex_pairing !== null}
+				<td>/</td>
+				<td><OntologyResult data={source_entity.complex_pairing} /></td>
+			{/if}
+		</tr>
+		<tr><td>
+			<Features {source_entity} classes={'ps-2'} />
+		</td></tr>
+	</table>
+</span>

--- a/src/lib/entity_displays/Concept.svelte
+++ b/src/lib/entity_displays/Concept.svelte
@@ -17,8 +17,10 @@
 				<td><OntologyResult data={source_entity.pairing_concept} /></td>
 			{/if}
 		</tr>
-		<tr><td>
-			<Features {source_entity} classes={'ps-2'} />
-		</td></tr>
+		<tr>
+			<td>
+				<Features {source_entity} classes={'ps-2'} />
+			</td>
+		</tr>
 	</table>
 </span>

--- a/src/lib/entity_displays/Features.svelte
+++ b/src/lib/entity_displays/Features.svelte
@@ -8,7 +8,25 @@
 	const last_feature_to_display = features.findLastIndex(({ name }) => !name.startsWith('Spare'))
 
 	const features_to_display = features.slice(0, last_feature_to_display + 1)
-	const feature_codes_to_display = feature_codes.slice(0, last_feature_to_display + 1)
+	const feature_codes_to_display = get_feature_codes_to_display()
+
+	function get_feature_codes_to_display() {
+		if (source_entity.category !== 'Clause')
+			return feature_codes.slice(0, last_feature_to_display + 1)
+
+		// Collapse meaningless features on clauses
+		// C-EDp00NNNNNNNNNNNNN. -> C-EDp00..
+		// C-IDp00NNNNNNNNNBNNN. -> C-IDp00..B..
+		// starting with index 5, collapse all 'N' and '.' values, leaving any unique values
+		const feature_code_chars = [...feature_codes]
+		const collapse_start = 5
+		const next_meaningful_char = feature_code_chars.findIndex((char, index) => index > collapse_start && !['N', '.'].includes(char))
+		const last_meaningful_char = feature_code_chars.findLastIndex(char => !['N', '.'].includes(char))
+
+		return next_meaningful_char === -1
+			? `${feature_codes.slice(0, collapse_start)}..`
+			: `${feature_codes.slice(0, collapse_start)}..${feature_codes.slice(next_meaningful_char, last_meaningful_char + 1)}..`
+	}
 
 	const CATEGORY_ABBREVIATIONS = new Map([
 		['Noun', 'N'],

--- a/src/lib/entity_displays/Features.svelte
+++ b/src/lib/entity_displays/Features.svelte
@@ -1,0 +1,59 @@
+<script>
+	/** @type {SourceEntity} */
+	export let source_entity
+	export let classes = ''
+
+	const { category, feature_codes, features } = source_entity
+
+	const last_feature_to_display = features.findLastIndex(({ name }) => !name.startsWith('Spare'))
+
+	const features_to_display = features.slice(0, last_feature_to_display + 1)
+	const feature_codes_to_display = feature_codes.slice(0, last_feature_to_display + 1)
+
+	const CATEGORY_ABBREVIATIONS = new Map([
+		['Noun', 'N'],
+		['Verb', 'V'],
+		['Adjective', 'Adj'],
+		['Adverb', 'Adv'],
+		['Adposition', 'Adp'],
+		['Conjunction', 'Con'],
+		['Phrasal', 'Phr'],
+		['Particle', 'Par'],
+		['Noun Phrase', 'NP'],
+		['Verb Phrase', 'VP'],
+		['Adjective Phrase', 'AdjP'],
+		['Adverb Phrase', 'AdvP'],
+		['Clause', 'C'],
+		['Paragraph', 'R'],
+		['Section', 'E'],
+		['period', 'period'],
+	])
+
+	/**
+	 * @param {EntityFeature} feature
+	 * @returns {boolean}
+	 */
+	function can_be_dulled({ value }) {
+		return value === 'No' || ['Un', 'No ', 'Not '].some(prefix => value.startsWith(prefix))
+	}
+</script>
+
+{#if features.length}
+	<div class="dropdown dropdown-hover dropdown-bottom {classes}">
+		<div class="overflow-x-auto dropdown-content z-[1] text-sm p-2 shadow-xl rounded-box w-96 bg-base-200 tracking-normal">
+			<ul>
+				<li class='font-semibold'>{category}</li>
+				{#each features_to_display as feature}
+					<li class='{can_be_dulled(feature) ? 'opacity-50' : ''}'>
+						<span class='font-semibold'>{feature.name}</span> = {feature.value}
+					</li>
+				{/each}
+			</ul>
+		</div>
+		<div role="button">
+			<span class="text-sm tracking-tight">
+				{CATEGORY_ABBREVIATIONS.get(category) ?? ''}-{feature_codes_to_display}
+			</span>
+		</div>
+	</div>
+{/if}

--- a/src/lib/entity_displays/Features.svelte
+++ b/src/lib/entity_displays/Features.svelte
@@ -3,7 +3,7 @@
 	export let source_entity
 	export let classes = ''
 
-	const { category, feature_codes, features } = source_entity
+	const { category, category_abbr, feature_codes, features } = source_entity
 
 	const last_feature_to_display = features.findLastIndex(({ name }) => !name.startsWith('Spare'))
 
@@ -11,7 +11,7 @@
 	const feature_codes_to_display = get_feature_codes_to_display()
 
 	function get_feature_codes_to_display() {
-		if (source_entity.category !== 'Clause')
+		if (category !== 'Clause')
 			return feature_codes.slice(0, last_feature_to_display + 1)
 
 		// Collapse meaningless features on clauses
@@ -27,25 +27,6 @@
 			? `${feature_codes.slice(0, collapse_start)}..`
 			: `${feature_codes.slice(0, collapse_start)}..${feature_codes.slice(next_meaningful_char, last_meaningful_char + 1)}..`
 	}
-
-	const CATEGORY_ABBREVIATIONS = new Map([
-		['Noun', 'N'],
-		['Verb', 'V'],
-		['Adjective', 'Adj'],
-		['Adverb', 'Adv'],
-		['Adposition', 'Adp'],
-		['Conjunction', 'Con'],
-		['Phrasal', 'Phr'],
-		['Particle', 'Par'],
-		['Noun Phrase', 'NP'],
-		['Verb Phrase', 'VP'],
-		['Adjective Phrase', 'AdjP'],
-		['Adverb Phrase', 'AdvP'],
-		['Clause', 'C'],
-		['Paragraph', 'R'],
-		['Section', 'E'],
-		['period', 'period'],
-	])
 
 	/**
 	 * @param {EntityFeature} feature
@@ -70,7 +51,7 @@
 		</div>
 		<div role="button">
 			<span class="text-sm tracking-tight">
-				{CATEGORY_ABBREVIATIONS.get(category) ?? ''}-{feature_codes_to_display}
+				{category_abbr}-{feature_codes_to_display}
 			</span>
 		</div>
 	</div>

--- a/src/lib/entity_displays/OntologyResult.svelte
+++ b/src/lib/entity_displays/OntologyResult.svelte
@@ -35,17 +35,12 @@
 </script>
 
 {#await fetch_ontology_data(data)}
-	<div class="dropdown dropdown-hover dropdown-bottom">
-		<div class="overflow-x-auto dropdown-content z-[1] text-sm p-2 shadow-xl rounded-box w-96 bg-base-200 tracking-normal">
-			loading ontology data...
-		</div>
-		<div role="button">
-			<span class="badge badge-lg border-base-content badge-outline px-4 py-5 text-lg">
-				<a class="link not-prose" href={get_ontology_url_for_link(data)} target="_blank">
-					{`${data.stem}-${data.sense}`}
-				</a>
-			</span>
-		</div>
+	<div role="button">
+		<span class="badge badge-lg border-base-content badge-outline px-4 py-5 text-lg">
+			<a class="link no-underline not-prose" href={get_ontology_url_for_link(data)} target="_blank">
+				{`${data.stem}-${data.sense}`}
+			</a>
+		</span>
 	</div>
 {:then ontology_data} 
 	{@const {stem, sense, level, gloss} = ontology_data}
@@ -55,7 +50,7 @@
 		</div>
 		<div role="button">
 			<span class="badge badge-lg border-base-content badge-outline px-4 py-5 text-lg {`L${level}`}">
-				<a class="link not-prose" href={get_ontology_url_for_link(ontology_data)} target="_blank">
+				<a class="link no-underline not-prose" href={get_ontology_url_for_link(ontology_data)} target="_blank">
 					{`${stem}-${sense}`}
 				</a>
 			</span>

--- a/src/lib/entity_displays/OntologyResult.svelte
+++ b/src/lib/entity_displays/OntologyResult.svelte
@@ -1,28 +1,64 @@
 <script>
 	import { PUBLIC_ONTOLOGY_API_HOST } from '$env/static/public'
 
-	/** @type {OntologyResult} */
+	/** @type {SourceConcept} */
 	export let data
 
-	const { stem, sense, level, gloss, part_of_speech } = data
+	/**
+	 * @param {SourceConcept} concept
+	 * @returns {Promise<OntologyResult>}
+	 */
+	async function fetch_ontology_data(concept) {
+		const { stem, sense, part_of_speech } = concept
+		const response = await fetch(`${PUBLIC_ONTOLOGY_API_HOST}/search?q=${stem}-${sense}&category=${part_of_speech}`)
+
+		const DEFAULT_DATA = {
+			...concept,
+			level: '',
+			gloss: '',
+		}
+
+		if (!response.ok) {
+			return DEFAULT_DATA
+		}
+
+		return (await response.json())[0] ?? DEFAULT_DATA
+	}
 
 	/**
+	 * @param {SourceConcept} concept
 	 * @returns {string} fully-qualified URL to the ontology API
 	 */
-	function get_ontology_url() {
+	function get_ontology_url_for_link({ stem, part_of_speech }) {
 		return `${PUBLIC_ONTOLOGY_API_HOST}/?q=${stem}&category=${part_of_speech}`
 	}
 </script>
 
-<div class="dropdown dropdown-hover dropdown-bottom">
-	<div class="overflow-x-auto dropdown-content z-[1] text-sm p-2 shadow-xl rounded-box w-96 bg-base-200 tracking-normal">
-		{gloss}
+{#await fetch_ontology_data(data)}
+	<div class="dropdown dropdown-hover dropdown-bottom">
+		<div class="overflow-x-auto dropdown-content z-[1] text-sm p-2 shadow-xl rounded-box w-96 bg-base-200 tracking-normal">
+			loading ontology data...
+		</div>
+		<div role="button">
+			<span class="badge badge-lg border-base-content badge-outline px-4 py-5 text-lg">
+				<a class="link not-prose" href={get_ontology_url_for_link(data)} target="_blank">
+					{`${data.stem}-${data.sense}`}
+				</a>
+			</span>
+		</div>
 	</div>
-	<div role="button">
-		<span class="badge badge-lg border-base-content badge-outline px-4 py-5 text-lg {`L${level}`}">
-			<a class="link not-prose" href={get_ontology_url()} target="_blank">
-				{`${stem}-${sense}`}
-			</a>
-		</span>
+{:then ontology_data} 
+	{@const {stem, sense, level, gloss} = ontology_data}
+	<div class="dropdown dropdown-hover dropdown-bottom">
+		<div class="overflow-x-auto dropdown-content z-[1] text-sm p-2 shadow-xl rounded-box w-96 bg-base-200 tracking-normal">
+			{gloss}
+		</div>
+		<div role="button">
+			<span class="badge badge-lg border-base-content badge-outline px-4 py-5 text-lg {`L${level}`}">
+				<a class="link not-prose" href={get_ontology_url_for_link(ontology_data)} target="_blank">
+					{`${stem}-${sense}`}
+				</a>
+			</span>
+		</div>
 	</div>
-</div>
+{/await}

--- a/src/lib/entity_displays/OntologyResult.svelte
+++ b/src/lib/entity_displays/OntologyResult.svelte
@@ -1,0 +1,28 @@
+<script>
+	import { PUBLIC_ONTOLOGY_API_HOST } from '$env/static/public'
+
+	/** @type {OntologyResult} */
+	export let data
+
+	const { stem, sense, level, gloss, part_of_speech } = data
+
+	/**
+	 * @returns {string} fully-qualified URL to the ontology API
+	 */
+	function get_ontology_url() {
+		return `${PUBLIC_ONTOLOGY_API_HOST}/?q=${stem}&category=${part_of_speech}`
+	}
+</script>
+
+<div class="dropdown dropdown-hover dropdown-bottom">
+	<div class="overflow-x-auto dropdown-content z-[1] text-sm p-2 shadow-xl rounded-box w-96 bg-base-200 tracking-normal">
+		{gloss}
+	</div>
+	<div role="button">
+		<span class="badge badge-lg border-base-content badge-outline px-4 py-5 text-lg {`L${level}`}">
+			<a class="link not-prose" href={get_ontology_url()} target="_blank">
+				{`${stem}-${sense}`}
+			</a>
+		</span>
+	</div>
+</div>

--- a/src/lib/entity_displays/Punctuation.svelte
+++ b/src/lib/entity_displays/Punctuation.svelte
@@ -1,0 +1,10 @@
+<script>
+	/** @type {SourceEntity} */
+	export let source_entity
+
+	export let classes = ''
+</script>
+
+<span class="pb-3 text-6xl font-thin {classes}">
+	{source_entity.value}
+</span>

--- a/src/lib/entity_displays/Punctuation.svelte
+++ b/src/lib/entity_displays/Punctuation.svelte
@@ -5,6 +5,6 @@
 	export let classes = ''
 </script>
 
-<span class="pb-3 text-6xl font-thin {classes}">
+<span class="px-1 pb-3 text-6xl font-thin {classes}">
 	{source_entity.value}
 </span>

--- a/src/lib/entity_displays/SourceEntities.svelte
+++ b/src/lib/entity_displays/SourceEntities.svelte
@@ -7,18 +7,34 @@
 	/** @type {SourceEntity[]} */
 	export let source_entities
 
+	const main_clauses = source_entities.reduce(clause_reducer, [])
+
+	/**
+	 * @param {SourceEntity[][]} clauses
+	 * @param {SourceEntity} source_entity
+	 */
+	function clause_reducer(clauses, source_entity) {
+		if (['{', '|'].includes(source_entity.value)) {
+			clauses.push([])
+		}
+		clauses.at(-1)?.push(source_entity)
+		return clauses
+	}
+
 	/** @type {[(entity: SourceEntity) => boolean, typeof Concept][]}*/
 	const component_filters = [
 		[({ value }) => ['{', '[', '('].includes(value), BoundaryStart],
 		[({ value }) => ['}', ']', ')'].includes(value), BoundaryEnd],
-		[({ ontology_result }) => !!ontology_result, Concept],
+		[({ concept }) => !!concept, Concept],
 		[() => true, Punctuation],
 	]
 </script>
 
-<div>
-	{#each source_entities as source_entity}
-		{@const component = component_filters.find(([filter]) => filter(source_entity))?.[1]}
-		<svelte:component this={component} {source_entity} />
-	{/each}
-</div>
+{#each main_clauses as main_clause}
+	<div class="py-4">
+		{#each main_clause as source_entity}
+			{@const component = component_filters.find(([filter]) => filter(source_entity))?.[1]}
+			<svelte:component this={component} {source_entity} />
+		{/each}
+	</div>
+{/each}

--- a/src/lib/entity_displays/SourceEntities.svelte
+++ b/src/lib/entity_displays/SourceEntities.svelte
@@ -1,0 +1,24 @@
+<script>
+	import Concept from './Concept.svelte'
+	import BoundaryEnd from './BoundaryEnd.svelte'
+	import BoundaryStart from './BoundaryStart.svelte'
+	import Punctuation from './Punctuation.svelte'
+
+	/** @type {SourceEntity[]} */
+	export let source_entities
+
+	/** @type {[(entity: SourceEntity) => boolean, typeof Concept][]}*/
+	const component_filters = [
+		[({ value }) => ['{', '[', '('].includes(value), BoundaryStart],
+		[({ value }) => ['}', ']', ')'].includes(value), BoundaryEnd],
+		[({ ontology_result }) => !!ontology_result, Concept],
+		[() => true, Punctuation],
+	]
+</script>
+
+<div>
+	{#each source_entities as source_entity}
+		{@const component = component_filters.find(([filter]) => filter(source_entity))?.[1]}
+		<svelte:component this={component} {source_entity} />
+	{/each}
+</div>

--- a/src/lib/index.js
+++ b/src/lib/index.js
@@ -1,0 +1,7 @@
+import Brand from './Brand.svelte'
+import SourceEntities from './entity_displays/SourceEntities.svelte'
+
+export {
+	Brand,
+	SourceEntities,
+}

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -1,0 +1,14 @@
+<script>
+	import '$lib/app.postcss'
+	import { Brand } from '$lib'
+</script>
+
+<!-- layout not handled by daisyUI, https://daisyui.com/docs/layout-and-typography -->
+
+<header class="grid grid-cols-[auto_1fr] mx-8 mt-8">
+	<Brand />
+</header>
+
+<main class="mx-8 mt-8">
+	<slot />
+</main>

--- a/src/routes/+server.js
+++ b/src/routes/+server.js
@@ -8,7 +8,7 @@ export async function GET({ locals: { db } }) {
 		FROM Sources
 	`
 
-	/** @type {import('@cloudflare/workers-types').D1Result<Source>} https://developers.cloudflare.com/d1/platform/client-api/#return-object */
+	/** @type {import('@cloudflare/workers-types').D1Result<SourceType>} https://developers.cloudflare.com/d1/platform/client-api/#return-object */
 	const { results } = await db.prepare(sql).all()
 
 	return json(results)

--- a/src/routes/[type]/[id_primary]/[id_secondary]/[id_tertiary]/+page.js
+++ b/src/routes/[type]/[id_primary]/[id_secondary]/[id_tertiary]/+page.js
@@ -1,0 +1,5 @@
+/** @type {import('./$types').PageLoad} */
+export async function load({ fetch, url }) {
+    const response = await fetch(url)
+    return await response.json()
+}

--- a/src/routes/[type]/[id_primary]/[id_secondary]/[id_tertiary]/+page.svelte
+++ b/src/routes/[type]/[id_primary]/[id_secondary]/[id_tertiary]/+page.svelte
@@ -1,0 +1,6 @@
+<script>
+    import { page } from '$app/stores'
+</script>
+
+<pre>{JSON.stringify($page.data, null, 2)}</pre>
+

--- a/src/routes/[type]/[id_primary]/[id_secondary]/[id_tertiary]/+page.svelte
+++ b/src/routes/[type]/[id_primary]/[id_secondary]/[id_tertiary]/+page.svelte
@@ -3,7 +3,12 @@
 
 	/** @type {Source} */
 	export let data
+
+	const reference = `${data.id_primary} ${data.id_secondary}:${data.id_tertiary}`
 </script>
 
-<SourceEntities source_entities={data.parsed_semantic_encoding} />
+<div class="flex justify-center prose max-w-full">
+	<h2>{reference}</h2>
+</div>
 
+<SourceEntities source_entities={data.parsed_semantic_encoding} />

--- a/src/routes/[type]/[id_primary]/[id_secondary]/[id_tertiary]/+page.svelte
+++ b/src/routes/[type]/[id_primary]/[id_secondary]/[id_tertiary]/+page.svelte
@@ -1,6 +1,9 @@
 <script>
-    import { page } from '$app/stores'
+	import { SourceEntities } from '$lib'
+
+	/** @type {Source} */
+	export let data
 </script>
 
-<pre>{JSON.stringify($page.data, null, 2)}</pre>
+<SourceEntities source_entities={data.parsed_semantic_encoding} />
 

--- a/src/routes/[type]/[id_primary]/[id_secondary]/[id_tertiary]/+server.js
+++ b/src/routes/[type]/[id_primary]/[id_secondary]/[id_tertiary]/+server.js
@@ -1,4 +1,5 @@
 // https://kit.svelte.dev/docs/routing#server
+import { transform_semantic_encoding } from '$lib/encoding/semantic_encoding'
 import { json } from '@sveltejs/kit'
 
 /** @type {import('./$types').RequestHandler} */
@@ -12,8 +13,12 @@ export async function GET({ locals: { db }, params: { type, id_primary, id_secon
 			AND id_tertiary = ?
 	`
 
-	/** @type {import('@cloudflare/workers-types').D1Result<Source>|null} https://developers.cloudflare.com/d1/platform/client-api/#return-object */
+	/** @type {Source|null} */
 	const result = await db.prepare(sql).bind(type, id_primary, id_secondary, id_tertiary).first()
+
+	if (result) {
+		result.parsed_semantic_encoding = await transform_semantic_encoding(result.semantic_encoding, db)
+	}
 
 	return json(result)
 }

--- a/src/routes/[type]/[id_primary]/[id_secondary]/[id_tertiary]/index.d.ts
+++ b/src/routes/[type]/[id_primary]/[id_secondary]/[id_tertiary]/index.d.ts
@@ -6,6 +6,7 @@ type Source = {
 	id_tertiary: string
 	phase_1_encoding: string
 	semantic_encoding: string
+	parsed_semantic_encoding: SourceEntity[]
 	comments: string
 	notes: string
 }

--- a/src/routes/index.d.ts
+++ b/src/routes/index.d.ts
@@ -1,3 +1,10 @@
 type SourceType = {
 	type: string
 }
+
+type Reference = {
+	type: string
+	id_primary: string
+	id_secondary: string
+	id_tertiary: string
+}

--- a/src/routes/index.d.ts
+++ b/src/routes/index.d.ts
@@ -1,3 +1,3 @@
-type Source = {
+type SourceType = {
 	type: string
 }

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,0 +1,14 @@
+import typography from '@tailwindcss/typography'
+import daisyui from 'daisyui'
+import type { Config } from 'tailwindcss'
+
+export default {
+	content: [
+		'./src/**/*.{html,js,svelte,ts}',
+	],
+
+	plugins: [
+		typography,
+		daisyui,
+	],
+} satisfies Config

--- a/vite.config.js
+++ b/vite.config.js
@@ -5,4 +5,8 @@ export default defineConfig({
 	plugins: [
 		sveltekit(),
 	],
+
+	server: {
+		host: 'localhost.tbta.bible',
+	},
 })

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -13,5 +13,5 @@ command = "pnpm build"
 
 [[d1_databases]]
 binding = "DB_Sources" # i.e. available in your Worker on env.DB
-database_name = "Sources.2024-10-25"
+database_name = "Sources.2025-02-13"
 database_id = "dummy-id"

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -13,5 +13,5 @@ command = "pnpm build"
 
 [[d1_databases]]
 binding = "DB_Sources" # i.e. available in your Worker on env.DB
-database_name = "Sources.2024-09-30"
-database_id = "3f9d2695-23cc-4bc0-8efc-a3f3331637e2"
+database_name = "Sources.2024-10-25"
+database_id = "dummy-id"


### PR DESCRIPTION
### Main layout
- Each sentence/main clause is in its own div, and are slightly separated for easier reading/grouping
- For now simply show the raw character for phrase and clause boundaries
- Each word is color-coded for level, like the Editor and Ontology
- Features show when hovered
![image](https://github.com/user-attachments/assets/e11efaeb-8a94-431f-9849-ed8734ed9c9c)

### Noun Features
- Grays out the features that are default/not applicable, to make the features that matter stand out
![image](https://github.com/user-attachments/assets/f53a4bf5-50bd-47e8-87ce-70e0b61554da)

### Clause Features
- Grays out the features that are default/not applicable, to make the features that matter stand out
- Condenses the features in the main view (with `..`) so it's not cluttered with meaningless characters
![image](https://github.com/user-attachments/assets/61e8770b-1523-4730-a749-65c2aaaeb3f6)

### Ontology info and link
- Pulls in data from the Ontology to show the level and gloss. In future we can add more info, similar to what TBTA shows
- Each word links to the Ontology
![image](https://github.com/user-attachments/assets/ac7797b6-bb31-474a-8cd4-d33ff1f1fac0)

### API now includes a parsed and simplified json structure for the semantic encoding
- This data will be used and displayed in the Ontology under the examples
![image](https://github.com/user-attachments/assets/dd650619-7135-428e-94de-093c90f3efce)
