### PR TITLE
Add status note or warning

### DIFF
--- a/src/routes/[type]/[id_primary]/[id_secondary]/[id_tertiary]/+page.svelte
+++ b/src/routes/[type]/[id_primary]/[id_secondary]/[id_tertiary]/+page.svelte
@@ -2,6 +2,7 @@
 	import { Navigation, SourceEntities } from '$lib'
 	import Settings from '$lib/settings/Settings.svelte'
 	import Sidebar from '$lib/sidebar/Sidebar.svelte'
+	import Icon from '@iconify/svelte'
 
 	/** @type {PageData} */
 	export let data
@@ -34,6 +35,22 @@
 	</div>
 </div>
 
+{#if source.status !== 'Ready to Translate' && source.parsed_semantic_encoding.length > 0}
+	{@const time_note = source.status === 'Final Review in Progress' ? 'almost' : 'not yet'}
+	<div role="alert" class="alert alert-warning">
+		<Icon icon="mdi:alert-outline" class="h-6 w-6" />
+		<span>Source data for this verse is still being reviewed, and is {time_note} ready for translation.</span>
+	</div>
+{:else if source.status === 'Not Started'}
+	<div class="flex justify-center prose max-w-full">
+		<p>No source data yet for this verse.</p>
+	</div>
+{:else if source.status !== 'Ready to Translate'}
+	<div class="flex justify-center prose max-w-full">
+		<p>Source data for this verse is currently being developed.</p>
+	</div>
+{/if}
+
 {#if source.parsed_semantic_encoding.length > 0}
 	<div class="flex h-screen">
 		<div class="transition-all duration-300 flex-[1_1_auto]" style="margin-right: {sidebar_open ? '24rem' : '0'};">
@@ -42,9 +59,5 @@
 		{#if sidebar_open}
 			<Sidebar {selected_entity} is_open={sidebar_open} {close_sidebar} noun_list={source.noun_list} />
 		{/if}
-	</div>
-{:else}
-	<div class="flex justify-center prose max-w-full">
-		<p>No source data yet for this verse.</p>
 	</div>
 {/if}

--- a/src/routes/[type]/[id_primary]/[id_secondary]/[id_tertiary]/index.d.ts
+++ b/src/routes/[type]/[id_primary]/[id_secondary]/[id_tertiary]/index.d.ts
@@ -7,8 +7,11 @@ type Source = {
 	phase_1_encoding: string
 	semantic_encoding: string
 	comments: string
+	status: SourceStatus
 	notes: string
 }
+
+type SourceStatus = 'Not Started' | 'Initial Analysis in Progress' | 'Initial Analysis Complete' | 'Final Review in Progress' | 'Ready to Translate'
 
 type ApiSource = Source & {
 	parsed_semantic_encoding: SourceEntity[]


### PR DESCRIPTION
Resolves #38 
Change the note or add a warning depending on the status of the verse's encoding. Below are the 5 possible states.

## No work being done
<img width="987" height="235" alt="image" src="https://github.com/user-attachments/assets/f0b22b3f-5e8f-4501-8a80-51f3ac514c4f" />

## Being developed
<img width="1064" height="227" alt="image" src="https://github.com/user-attachments/assets/882f74f0-06f0-44fa-84d3-d14d38ad25ec" />

## Not yet ready
<img width="1051" height="549" alt="image" src="https://github.com/user-attachments/assets/27dc6189-ebb9-444a-b383-88e77ff0f7a3" />

## Almost ready
<img width="1059" height="474" alt="image" src="https://github.com/user-attachments/assets/798da574-ada1-4ed7-a97c-be83fbba87d9" />

## Ready to translate
<img width="1053" height="426" alt="image" src="https://github.com/user-attachments/assets/dc211135-4418-4f8a-997f-f34f846267ca" />