### PR TITLE
Statuses api

### DIFF
--- a/src/lib/data/status.ts
+++ b/src/lib/data/status.ts
@@ -11,7 +11,10 @@ export async function get_verse_statuses(db: D1Database, references: Reference[]
 	`
 
 	const prepared_statement = db.prepare(sql)
-	const bound_statements = references.map(({ type, id_primary, id_secondary, id_tertiary }) => prepared_statement.bind(type, id_primary, id_secondary, id_tertiary))
+	const bound_statements = references.map(({ type, id_primary, id_secondary, id_tertiary }) =>
+		prepared_statement.bind(type, id_primary, id_secondary.toString(), id_tertiary.toString()),
+	)
+
 	const batch_result = await db.batch<{ status: SourceStatus }>(bound_statements)
 	const statuses = batch_result.map(r => r.results[0]?.status || 'Not Started')
 

--- a/src/lib/data/status.ts
+++ b/src/lib/data/status.ts
@@ -1,5 +1,71 @@
 import type { D1Database } from '@cloudflare/workers-types'
 
+interface StatusCountResult {
+	not_started_count: number
+	in_progress_count: number
+	initial_complete_count: number
+	review_count: number
+	ready_count: number
+	total_count: number
+}
+
+export async function get_book_status(db: D1Database, reference: StatusRequestReference): Promise<StatusResult> {
+	const sql = `
+		SELECT
+			COUNT(*) FILTER (WHERE status = 'Not Started') AS not_started_count,
+			COUNT(*) FILTER (WHERE status = 'Initial Analysis in Progress') AS in_progress_count,
+			COUNT(*) FILTER (WHERE status = 'Initial Analysis Complete') AS initial_complete_count,
+			COUNT(*) FILTER (WHERE status = 'Final Review in Progress') AS review_count,
+			COUNT(*) FILTER (WHERE status = 'Ready to Translate') AS ready_count,
+			COUNT(*) AS total_count
+		FROM Sources
+		WHERE type LIKE ?
+			AND id_primary LIKE ?
+	`
+
+	const result = await db.prepare(sql).bind(reference.type, reference.id_primary).first<StatusCountResult>()
+	return {
+		reference,
+		status: get_status_from_counts(result),
+	}
+}
+
+export async function get_chapter_status(db: D1Database, reference: StatusRequestReference): Promise<StatusResult> {
+	const sql = `
+		SELECT
+			COUNT(*) FILTER (WHERE status = 'Not Started') AS not_started_count,
+			COUNT(*) FILTER (WHERE status = 'Initial Analysis in Progress') AS in_progress_count,
+			COUNT(*) FILTER (WHERE status = 'Initial Analysis Complete') AS initial_complete_count,
+			COUNT(*) FILTER (WHERE status = 'Final Review in Progress') AS review_count,
+			COUNT(*) FILTER (WHERE status = 'Ready to Translate') AS ready_count,
+			COUNT(*) AS total_count
+		FROM Sources
+		WHERE type LIKE ?
+			AND id_primary LIKE ?
+			AND id_secondary = ?
+	`
+
+	const prepared_statement = db.prepare(sql).bind(reference.type, reference.id_primary, reference.id_secondary!.toString())
+	const result = await prepared_statement.first<StatusCountResult>()
+	return {
+		reference,
+		status: get_status_from_counts(result),
+	}
+}
+
+function get_status_from_counts(status_counts: StatusCountResult|null): SourceStatus {
+	const status_count_mapping: [(status_counts: StatusCountResult) => boolean, SourceStatus][] = [
+		[({ total_count, ready_count }) => total_count === ready_count, 'Ready to Translate'],
+		[({ total_count, not_started_count }) => total_count === not_started_count, 'Not Started'],
+		[({ not_started_count }) => not_started_count > 0, 'Initial Analysis in Progress'],
+		[({ in_progress_count }) => in_progress_count > 0, 'Initial Analysis in Progress'],
+		[({ review_count }) => review_count > 0, 'Final Review in Progress'],
+		[() => true, 'Initial Analysis Complete'],
+	]
+
+	return status_counts ? status_count_mapping.find(([predicate]) => predicate(status_counts))![1] : 'Not Started'
+}
+
 export async function get_verse_statuses(db: D1Database, references: Reference[]): Promise<StatusResult[]> {
 	const sql = `
 		SELECT status

--- a/src/lib/data/status.ts
+++ b/src/lib/data/status.ts
@@ -1,0 +1,23 @@
+import type { D1Database } from '@cloudflare/workers-types'
+
+export async function get_verse_statuses(db: D1Database, references: Reference[]): Promise<StatusResult[]> {
+	const sql = `
+		SELECT status
+		FROM Sources
+		WHERE type LIKE ?
+			AND id_primary LIKE ?
+			AND id_secondary = ?
+			AND id_tertiary = ?
+	`
+
+	const prepared_statement = db.prepare(sql)
+	const bound_statements = references.map(({ type, id_primary, id_secondary, id_tertiary }) => prepared_statement.bind(type, id_primary, id_secondary, id_tertiary))
+	const batch_result = await db.batch<{ status: SourceStatus }>(bound_statements)
+	const statuses = batch_result.map(r => r.results[0]?.status || 'Not Started')
+
+	const results = references.map((reference, i) => ({
+		reference,
+		status: statuses[i],
+	}))
+	return results
+}

--- a/src/routes/[type]/[id_primary]/[id_secondary]/[id_tertiary]/index.d.ts
+++ b/src/routes/[type]/[id_primary]/[id_secondary]/[id_tertiary]/index.d.ts
@@ -11,8 +11,6 @@ type Source = {
 	notes: string
 }
 
-type SourceStatus = 'Not Started' | 'Initial Analysis in Progress' | 'Initial Analysis Complete' | 'Final Review in Progress' | 'Ready to Translate'
-
 type ApiSource = Source & {
 	parsed_semantic_encoding: SourceEntity[]
 }

--- a/src/routes/index.d.ts
+++ b/src/routes/index.d.ts
@@ -12,3 +12,5 @@ type Reference = {
 type ViewSettings = {
 	show_hover_popups: boolean
 }
+
+type SourceStatus = 'Not Started' | 'Initial Analysis in Progress' | 'Initial Analysis Complete' | 'Final Review in Progress' | 'Ready to Translate'

--- a/src/routes/lookup/status/+server.js
+++ b/src/routes/lookup/status/+server.js
@@ -1,0 +1,12 @@
+import { get_verse_statuses } from '$lib/data/status'
+import { json } from '@sveltejs/kit'
+
+/** @type {import('./$types').RequestHandler} */
+export async function POST({ locals: { db }, request }) {
+	/** @type {Reference[]} */
+	const references = await request.json()
+
+	const results = await get_verse_statuses(db, references)
+
+	return json(results)
+}

--- a/src/routes/lookup/status/[type]/[id_primary]/+server.js
+++ b/src/routes/lookup/status/[type]/[id_primary]/+server.js
@@ -1,0 +1,14 @@
+import { get_book_status } from '$lib/data/status'
+import { json } from '@sveltejs/kit'
+
+/** @type {import('./$types').RequestHandler} */
+export async function GET({ locals: { db }, params: { type, id_primary } }) {
+	const result = await get_book_status(db, { type, id_primary })
+
+	const SIX_HOUR_CACHE = {
+		'cache-control': `max-age=${6 * 60 * 60}`,
+	}
+	return json(result, {
+		headers: SIX_HOUR_CACHE,
+	})
+}

--- a/src/routes/lookup/status/index.d.ts
+++ b/src/routes/lookup/status/index.d.ts
@@ -1,4 +1,10 @@
 type StatusResult = {
-	reference: Reference
+	reference: StatusRequestReference
 	status: SourceStatus
+}
+
+type StatusRequestReference = {
+	type?: string
+	id_primary: string
+	id_secondary?: string
 }

--- a/src/routes/lookup/status/index.d.ts
+++ b/src/routes/lookup/status/index.d.ts
@@ -1,0 +1,4 @@
+type StatusResult = {
+	reference: Reference
+	status: SourceStatus
+}


### PR DESCRIPTION
Add endpoints to:
- get status of verses in bulk
  - POST request at `lookup/status`
- get status of books - will be used in the Ontology
  - GET request at `lookup/status/[type]/[id_primary]` eg. `lookup/status/Bible/Genesis`

Also added a function to get the status of chapters, though it's not exposed in an API endpoint at this point. It will be used within a status UI page.