### PR TITLE
Add page for viewing source features by category

### DIFF
--- a/src/lib/encoding/index.d.ts
+++ b/src/lib/encoding/index.d.ts
@@ -49,7 +49,11 @@ type TargetApiFeatureResult = {
 	lexical: TargetApiFeature[]
 }
 
-type FeatureValueInfo = { value: FeatureValue, code: string }
+type FeatureValueInfo = {
+	value: FeatureValue
+	code: string
+	example?: string
+}
 type FeatureInfo = { name: FeatureName, values: FeatureValueInfo[] }
 type FeatureMap = Map<CategoryName, FeatureInfo[]>
 

--- a/src/lib/encoding/lookups.ts
+++ b/src/lib/encoding/lookups.ts
@@ -38,3 +38,18 @@ export const CATEGORY_ABBREVIATIONS = new Map([
 ])
 
 export const WORD_ENTITY_CATEGORIES = new Set(['Noun', 'Verb', 'Adjective', 'Adverb', 'Adposition', 'Conjunction', 'Phrasal', 'Particle'])
+
+export const GRAMMAR_ONLY_FEATURES = [
+	'Verb-Adjective Degree',
+	'Verb-Target Tense & Form',
+	'Noun Phrase-Thing-Thing Relationship',
+	'Noun Phrase-Relativized',
+	'Noun Phrase-Specific Phrase Structure Rule Code 1',
+	'Verb Phrase-Specific Phrase Structure Rule Code 1',
+	'Adjective Phrase-Specific Phrase Structure Rule Code 1',
+	'Adverb Phrase-Specific Phrase Structure Rule Code 1',
+	'Clause-Speech Style',
+	'Clause-Notional Structure Schema',
+	'Clause-Specific Phrase Structure Rule Code 1',
+	'Clause-Specific Phrase Structure Rule Code 2',
+]

--- a/src/routes/lookup/features/+page.server.js
+++ b/src/routes/lookup/features/+page.server.js
@@ -1,0 +1,16 @@
+import { load_source_feature_map } from '$lib/encoding/features'
+import { GRAMMAR_ONLY_FEATURES } from '$lib/encoding/lookups'
+
+/** @type {import('./$types').PageServerLoad} */
+export async function load({ locals: { db } }) {
+	const features = await load_source_feature_map(db)
+
+	const features_to_show = new Map([...features.entries()].map(([category, features]) => {
+		const filtered_features = features.filter(({ name }) => !name.startsWith('Spare') && !GRAMMAR_ONLY_FEATURES.includes(`${category}-${name}`))
+		return [category, filtered_features]
+	}))
+
+	return {
+		features: features_to_show,
+	}
+}

--- a/src/routes/lookup/features/+page.svelte
+++ b/src/routes/lookup/features/+page.svelte
@@ -1,0 +1,48 @@
+<script>
+	const { data } = $props()
+
+	const features_by_category = data.features
+
+	let chosen_category = $state('Noun')
+	let features_to_show = $derived(features_by_category.get(chosen_category) || [])
+
+</script>
+
+<div class="prose">
+	<h2>Features</h2>
+</div>
+
+<div class="my-3">
+	Category
+	<select class="select" bind:value={chosen_category}>
+		{#each features_by_category.keys() as category}
+			<option value={category}>{category}</option>
+		{/each}
+	</select>
+</div>
+
+{#if features_to_show.length === 0}
+	<div>No source features yet.</div>
+{/if}
+
+{#each features_to_show as { name, values }}
+	<div class="collapse collapse-arrow bg-base-100 border-base-300 border">
+		<input type="checkbox" />
+		<div class="collapse-title font-semibold after:start-5 after:end-auto py-2 pe-4 ps-12">
+			{name}
+		</div>
+		<div class="collapse-content">
+			<table class="table table-sm table-zebra table-fixed">
+				<tbody>
+					{#each values as { value, code, example }}
+						<tr>
+							<td>{value}</td>
+							<td>{code}</td>
+							<td>{@html example?.replaceAll(/<BLD>(.*?)<>/g, '<span class="font-bold">$1</span>') || ''}</td>
+						</tr>
+					{/each}
+				</tbody>
+			</table>
+		</div>
+	</div>
+{/each}


### PR DESCRIPTION
A page to view all the source features, filtered by category. At the url `/lookup/features`.

<img width="1567" height="908" alt="image" src="https://github.com/user-attachments/assets/87eafb5d-6afa-4aa6-bfe1-442fc1fe3781" />

I'm very open to UI suggestions
