### PR TITLE
Add page to view status of all books

### DIFF
--- a/src/lib/data/lookups.js
+++ b/src/lib/data/lookups.js
@@ -1,0 +1,90 @@
+/**
+ * TODO add and use an 'order' field in the db
+ * @type {Record<string, Record<number, string>>}
+ */
+export const ordered_primary_ids = {
+	'Bible': {
+		1: 'Genesis',
+		2: 'Exodus',
+		3: 'Leviticus',
+		4: 'Numbers',
+		5: 'Deuteronomy',
+		6: 'Joshua',
+		7: 'Judges',
+		8: 'Ruth',
+		9: '1 Samuel',
+		10: '2 Samuel',
+		11: '1 Kings',
+		12: '2 Kings',
+		13: '1 Chronicles',
+		14: '2 Chronicles',
+		15: 'Ezra',
+		16: 'Nehemiah',
+		17: 'Esther',
+		18: 'Job',
+		19: 'Psalms',
+		20: 'Proverbs',
+		21: 'Ecclesiastes',
+		22: 'Song of Solomon',
+		23: 'Isaiah',
+		24: 'Jeremiah',
+		25: 'Lamentations',
+		26: 'Ezekiel',
+		27: 'Daniel',
+		28: 'Hosea',
+		29: 'Joel',
+		30: 'Amos',
+		31: 'Obadiah',
+		32: 'Jonah',
+		33: 'Micah',
+		34: 'Nahum',
+		35: 'Habakkuk',
+		36: 'Zephaniah',
+		37: 'Haggai',
+		38: 'Zechariah',
+		39: 'Malachi',
+		40: 'Matthew',
+		41: 'Mark',
+		42: 'Luke',
+		43: 'John',
+		44: 'Acts',
+		45: 'Romans',
+		46: '1 Corinthians',
+		47: '2 Corinthians',
+		48: 'Galatians',
+		49: 'Ephesians',
+		50: 'Philippians',
+		51: 'Colossians',
+		52: '1 Thessalonians',
+		53: '2 Thessalonians',
+		54: '1 Timothy',
+		55: '2 Timothy',
+		56: 'Titus',
+		57: 'Philemon',
+		58: 'Hebrews',
+		59: 'James',
+		60: '1 Peter',
+		61: '2 Peter',
+		62: '1 John',
+		63: '2 John',
+		64: '3 John',
+		65: 'Jude',
+		66: 'Revelation',
+	},
+}
+
+/**
+ * TODO somehow store in the db
+ * @type {Record<string, Record<string, [number, number]>>}
+ */
+export const primary_id_groupings = {
+	'Bible': {
+		'Old Testament': [1, 39],
+		'New Testament': [40, 66],
+	},
+}
+
+/**
+ * @type {SourceStatus[]}
+ */
+export const status_list = ['Not Started', 'Initial Analysis in Progress', 'Initial Analysis Complete', 'Final Review in Progress', 'Ready to Translate']

--- a/src/lib/data/navigation.js
+++ b/src/lib/data/navigation.js
@@ -1,77 +1,5 @@
 import { get_secondary_ids, get_source_data, get_tertiary_ids } from './read'
-
-/**
- * TODO add and use an 'order' field in the db
- * @type {Record<number, string>}
- */
-const bible_books = {
-	1: 'Genesis',
-	2: 'Exodus',
-	3: 'Leviticus',
-	4: 'Numbers',
-	5: 'Deuteronomy',
-	6: 'Joshua',
-	7: 'Judges',
-	8: 'Ruth',
-	9: '1 Samuel',
-	10: '2 Samuel',
-	11: '1 Kings',
-	12: '2 Kings',
-	13: '1 Chronicles',
-	14: '2 Chronicles',
-	15: 'Ezra',
-	16: 'Nehemiah',
-	17: 'Esther',
-	18: 'Job',
-	19: 'Psalms',
-	20: 'Proverbs',
-	21: 'Ecclesiastes',
-	22: 'Song of Solomon',
-	23: 'Isaiah',
-	24: 'Jeremiah',
-	25: 'Lamentations',
-	26: 'Ezekiel',
-	27: 'Daniel',
-	28: 'Hosea',
-	29: 'Joel',
-	30: 'Amos',
-	31: 'Obadiah',
-	32: 'Jonah',
-	33: 'Micah',
-	34: 'Nahum',
-	35: 'Habakkuk',
-	36: 'Zephaniah',
-	37: 'Haggai',
-	38: 'Zechariah',
-	39: 'Malachi',
-	40: 'Matthew',
-	41: 'Mark',
-	42: 'Luke',
-	43: 'John',
-	44: 'Acts',
-	45: 'Romans',
-	46: '1 Corinthians',
-	47: '2 Corinthians',
-	48: 'Galatians',
-	49: 'Ephesians',
-	50: 'Philippians',
-	51: 'Colossians',
-	52: '1 Thessalonians',
-	53: '2 Thessalonians',
-	54: '1 Timothy',
-	55: '2 Timothy',
-	56: 'Titus',
-	57: 'Philemon',
-	58: 'Hebrews',
-	59: 'James',
-	60: '1 Peter',
-	61: '2 Peter',
-	62: '1 John',
-	63: '2 John',
-	64: '3 John',
-	65: 'Jude',
-	66: 'Revelation',
-}
+import { ordered_primary_ids } from './lookups'
 
 /**
  * @param {import('@cloudflare/workers-types').D1Database} db
@@ -102,12 +30,12 @@ export async function get_previous_reference(db, reference) {
 	}
 
 	// try decrementing id_primary (by index)
-	const book_index = find_book_index(reference.id_primary)
+	const book_index = find_book_index(reference)
 	if (!book_index) {
 		return null
 	}
 
-	const previous_book = bible_books[book_index - 1]
+	const previous_book = ordered_primary_ids[reference.type]?.[book_index - 1]
 	if (!previous_book) {
 		return null
 	}
@@ -149,12 +77,12 @@ export async function get_next_reference(db, reference) {
 	}
 
 	// try incrementing id_primary (by index)
-	const book_index = find_book_index(reference.id_primary)
+	const book_index = find_book_index(reference)
 	if (!book_index) {
 		return null
 	}
 
-	const next_book = bible_books[book_index + 1]
+	const next_book = ordered_primary_ids[reference.type]?.[book_index + 1]
 	if (!next_book) {
 		return null
 	}
@@ -169,12 +97,16 @@ export async function get_next_reference(db, reference) {
 }
 
 /**
- * @param {string} book_name
+ * @param {Reference} reference
  * @returns {number|undefined}
  */
-function find_book_index(book_name) {
-	const upper_book_name = book_name.toUpperCase()
-	const index_string = Object.entries(bible_books).find(([, name]) => name.toUpperCase() === upper_book_name)?.[0]
+function find_book_index(reference) {
+	const book_names = ordered_primary_ids[reference.type]
+	if (!book_names) {
+		return undefined
+	}
+	const upper_book_name = reference.id_primary.toUpperCase()
+	const index_string = Object.entries(book_names).find(([, name]) => name.toUpperCase() === upper_book_name)?.[0]
 	return index_string ? Number(index_string) : undefined
 }
 

--- a/src/lib/data/status.ts
+++ b/src/lib/data/status.ts
@@ -1,4 +1,5 @@
 import type { D1Database } from '@cloudflare/workers-types'
+import { get_primary_ids } from './read'
 
 interface StatusCountResult {
 	not_started_count: number
@@ -7,6 +8,11 @@ interface StatusCountResult {
 	review_count: number
 	ready_count: number
 	total_count: number
+}
+
+export async function get_all_book_statuses(db: D1Database, type: string): Promise<StatusResult[]> {
+	const primary_ids = await get_primary_ids(db, type)
+	return await Promise.all(primary_ids.map(({ id_primary }) => get_book_status(db, { type, id_primary })))
 }
 
 export async function get_book_status(db: D1Database, reference: StatusRequestReference): Promise<StatusResult> {

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -15,3 +15,10 @@
 <main class="mx-8 mt-8">
 	<slot />
 </main>
+
+<footer class="footer footer-horizontal mt-20 max-w-none bg-neutral p-10 text-neutral-content">
+	<nav class="justify-self-end">
+		<a href="/lookup/status/Bible" class="link link-hover">Bible encoding status</a>
+		<a href="/lookup/features" class="link link-hover">Source features list</a>
+	</nav>
+</footer>

--- a/src/routes/lookup/status/[type]/+page.server.js
+++ b/src/routes/lookup/status/[type]/+page.server.js
@@ -1,0 +1,27 @@
+import { get_all_book_statuses } from '$lib/data/status'
+import { ordered_primary_ids, primary_id_groupings } from '$lib/data/lookups.js'
+
+/** @type {import('./$types').PageServerLoad} */
+export async function load({ locals: { db }, params: { type } }) {
+	const statuses = await get_all_book_statuses(db, type)
+
+	// group and order the primary_ids
+	const groupings = primary_id_groupings[type] || { [type]: [1, statuses.length] }
+	const primary_id_to_order_map = Object.fromEntries(Object.entries(ordered_primary_ids[type]).map(([i, name]) => ([name, Number(i)])))
+
+	let status_groups = Object.entries(groupings).map(([group_name, range]) => {
+		const [start, end] = range
+		const group_statuses = statuses.filter(({ reference: { id_primary } }) => {
+			const order = primary_id_to_order_map[id_primary]
+			return order >= start && order <= end
+		}).toSorted((a, b) => primary_id_to_order_map[a.reference.id_primary] - primary_id_to_order_map[b.reference.id_primary])
+		return {
+			group_name,
+			statuses: group_statuses,
+		}
+	})
+
+	return {
+		status_groups,
+	}
+}

--- a/src/routes/lookup/status/[type]/+page.svelte
+++ b/src/routes/lookup/status/[type]/+page.svelte
@@ -1,0 +1,45 @@
+<script>
+	import { status_list } from '$lib/data/lookups.js'
+
+	const { data } = $props()
+
+	const status_groups = data.status_groups
+	let selected_status = $state('All')
+
+	let filtered_status_groups = $derived(status_groups.map(({ group_name, statuses }) => ({
+		group_name,
+		statuses: selected_status === 'All' ? statuses : statuses.filter(s => s.status === selected_status)
+	})))
+</script>
+
+<div class="prose">
+	<h2>Encoding Status</h2>
+</div>
+
+<div class="my-3">
+	Status
+	<select class="select" bind:value={selected_status}>
+		<option value="All" selected>All</option>
+		{#each status_list.toReversed() as status}
+			<option value={status}>{status}</option>
+		{/each}
+	</select>
+</div>
+
+<div class="flex py-3 gap-7">
+	{#each filtered_status_groups as { group_name, statuses }}
+		<div class="flex-auto">
+			<table class="table table-zebra">
+				<thead><tr><th>{group_name}</th></tr></thead>
+				<tbody>
+					{#each statuses as { reference: { id_primary }, status }}
+						<tr>
+							<th>{id_primary}</th>
+							<td>{status}</td>
+						</tr>
+					{/each}
+				</tbody>
+			</table>
+		</div>
+	{/each}
+</div>


### PR DESCRIPTION
A simple page to view the encoding status of all Bible books.

<img width="1258" height="723" alt="image" src="https://github.com/user-attachments/assets/b5b5666f-d3af-4bda-a6bc-0ad881d06930" />

<img width="1287" height="773" alt="image" src="https://github.com/user-attachments/assets/02805fc8-7c4c-480e-ae5f-1027023fd177" />

Currently it feels like it's pretty slow to load, and I would be happy to discuss ways to make it more efficient.

We can fine-tune the UI at a later point, such as adding color coding and such.

Also added a footer with convenient links to this page and the features page:
<img width="369" height="234" alt="image" src="https://github.com/user-attachments/assets/45607c37-8700-4a71-b19f-5e9ae00c830f" />
