### PR TITLE
Add ability to copy/paste/delete entities

### DIFF
--- a/src/lib/edit/EntityContextMenu.svelte
+++ b/src/lib/edit/EntityContextMenu.svelte
@@ -1,0 +1,37 @@
+<script lang="ts">
+	import { is_boundary_start } from '$lib/encoding/entity_filters'
+
+	interface Props {
+		source_entities: PageSourceEntity[]
+		data: EntityContextMenuData
+		onclose: (recalculate: boolean) => void
+	}
+	let { source_entities = $bindable(), data, onclose }: Props = $props()
+
+	let entity = $derived(source_entities[data.entity_id])
+
+	function delete_entity() {
+		source_entities.splice(data.entity_id, 1)
+		onclose(true)
+	}
+
+	function delete_entity_and_children() {
+		const entity_id = data.entity_id
+		const last_child_index = source_entities.findLastIndex(entity => entity.parent_id === entity_id)
+		source_entities.splice(entity_id, last_child_index - entity_id + 1)
+		onclose(true)
+	}
+</script>
+
+<!-- svelte-ignore a11y_click_events_have_key_events -->
+<!-- svelte-ignore a11y_no_static_element_interactions -->
+<div class="card shadow-lg bg-base-100 min-w-50" style="position: fixed; left: {data.x}px; top: {data.y}px; z-index: 60;"
+		onclick={e => e.stopPropagation()}
+		onmouseleave={() => onclose(false)}>
+	<ul class="menu w-full">
+		<li><button onclick={delete_entity}>Delete</button></li>
+		{#if is_boundary_start(entity)}
+			<li><button onclick={delete_entity_and_children}>Delete whole {entity.category}</button></li>
+		{/if}
+	</ul>
+</div>

--- a/src/lib/edit/EntityContextMenu.svelte
+++ b/src/lib/edit/EntityContextMenu.svelte
@@ -1,25 +1,65 @@
 <script lang="ts">
 	import { is_boundary_start } from '$lib/encoding/entity_filters'
+	import { entity_clipboard } from './clipboard.svelte'
 
 	interface Props {
 		source_entities: PageSourceEntity[]
 		data: EntityContextMenuData
-		onclose: (recalculate: boolean) => void
+		onclose: (recalculate: boolean, id_to_select?: number) => void
 	}
 	let { source_entities = $bindable(), data, onclose }: Props = $props()
 
 	let entity = $derived(source_entities[data.entity_id])
 
-	function delete_entity() {
-		source_entities.splice(data.entity_id, 1)
+	function paste_before() {
+		const new_entities = entity_clipboard.paste()
+		if (new_entities !== null) {
+			source_entities.splice(data.entity_id, 0, ...new_entities)
+			onclose(true, data.entity_id)
+		} else {
+			onclose(false)
+		}
+	}
+
+	function paste_after() {
+		const new_entities = entity_clipboard.paste()
+		if (new_entities !== null) {
+			source_entities.splice(data.entity_id + 1, 0, ...new_entities)
+			onclose(true, data.entity_id + 1)
+		} else {
+			onclose(false)
+		}
+	}
+
+	function cut_entity() {
+		const entity_range = source_entities.splice(data.entity_id, get_range_length())
+		entity_clipboard.copy(entity_range)
 		onclose(true)
 	}
 
+	function copy_entity() {
+		const entity_range = source_entities.slice(data.entity_id, data.entity_id + get_range_length())
+		entity_clipboard.copy(entity_range)
+		onclose(false)
+	}
+
+	function delete_entity() {
+		source_entities.splice(data.entity_id, 1)
+		onclose(true, data.entity_id - 1)
+	}
+
 	function delete_entity_and_children() {
-		const entity_id = data.entity_id
-		const last_child_index = source_entities.findLastIndex(entity => entity.parent_id === entity_id)
-		source_entities.splice(entity_id, last_child_index - entity_id + 1)
-		onclose(true)
+		source_entities.splice(data.entity_id, get_range_length())
+		onclose(true, data.entity_id - 1)
+	}
+
+	function get_range_length() {
+		if (is_boundary_start(entity)) {
+			const last_child_index = source_entities.findLastIndex(entity => entity.parent_id === data.entity_id)
+			return last_child_index - data.entity_id + 1
+		} else {
+			return 1
+		}
 	}
 </script>
 
@@ -29,6 +69,12 @@
 		onclick={e => e.stopPropagation()}
 		onmouseleave={() => onclose(false)}>
 	<ul class="menu w-full">
+		{#if entity_clipboard.has_value()}
+			<li><button onclick={paste_before}>Paste before</button></li>
+			<li><button onclick={paste_after}>Paste after</button></li>
+		{/if}
+		<li><button onclick={copy_entity}>Copy</button></li>
+		<li><button onclick={cut_entity}>Move</button></li>
 		<li><button onclick={delete_entity}>Delete</button></li>
 		{#if is_boundary_start(entity)}
 			<li><button onclick={delete_entity_and_children}>Delete whole {entity.category}</button></li>

--- a/src/lib/edit/EntityContextMenu.svelte
+++ b/src/lib/edit/EntityContextMenu.svelte
@@ -44,11 +44,6 @@
 	}
 
 	function delete_entity() {
-		source_entities.splice(data.entity_id, 1)
-		onclose(true, data.entity_id - 1)
-	}
-
-	function delete_entity_and_children() {
 		source_entities.splice(data.entity_id, get_range_length())
 		onclose(true, data.entity_id - 1)
 	}
@@ -76,8 +71,5 @@
 		<li><button onclick={copy_entity}>Copy</button></li>
 		<li><button onclick={cut_entity}>Move</button></li>
 		<li><button onclick={delete_entity}>Delete</button></li>
-		{#if is_boundary_start(entity)}
-			<li><button onclick={delete_entity_and_children}>Delete whole {entity.category}</button></li>
-		{/if}
 	</ul>
 </div>

--- a/src/lib/edit/SourceEntitiesEdit.svelte
+++ b/src/lib/edit/SourceEntitiesEdit.svelte
@@ -61,11 +61,15 @@
 		entity_context_menu_open = true
 	}
 
-	function close_entity_context_menu(recalculate: boolean) {
+	function close_entity_context_menu(recalculate: boolean, id_to_select?: number) {
 		entity_context_menu_open = false
 		if (recalculate) {
 			structure_entities(source_entities)
-			on_entity_select(null)
+			if (id_to_select) {
+				entity_focus(id_to_select)
+			} else if (id_to_select === -1) {
+				on_entity_select(null)
+			}
 		}
 	}
 

--- a/src/lib/edit/SourceEntitiesEdit.svelte
+++ b/src/lib/edit/SourceEntitiesEdit.svelte
@@ -1,20 +1,22 @@
 <script lang="ts">
-	import Concept from './Concept.svelte'
-	import BoundaryEnd from './BoundaryEnd.svelte'
-	import BoundaryStart from './BoundaryStart.svelte'
-	import Punctuation from './Punctuation.svelte'
+	import Concept from '../entity_displays/Concept.svelte'
+	import BoundaryEnd from '../entity_displays/BoundaryEnd.svelte'
+	import BoundaryStart from '../entity_displays/BoundaryStart.svelte'
+	import Punctuation from '../entity_displays/Punctuation.svelte'
 	import { is_boundary_end, is_boundary_start } from '$lib/encoding/entity_filters'
+	import EntityContextMenu from './EntityContextMenu.svelte'
+	import { structure_entities } from '$lib/encoding/structured'
 
 	type IndexRange = [number, number]
 
 	interface Props {
 		source_entities: PageSourceEntity[]
 		selected_entity: PageSourceEntity|null
-		on_entity_select: (entity: PageSourceEntity) => void
+		on_entity_select: (entity: PageSourceEntity|null) => void
 	}
-	let { source_entities, selected_entity, on_entity_select }: Props = $props()
+	let { source_entities = $bindable(), selected_entity, on_entity_select }: Props = $props()
 
-	let entity_divs: HTMLElement[] = $state([])
+	// let entity_divs: HTMLElement[] = $state([])
 
 	let hover_range: IndexRange | null = $state(null)
 	let select_range: IndexRange | null = $derived(
@@ -24,7 +26,7 @@
 				: [selected_entity.id, selected_entity.id]
 	)
 
-	let entity_highlights = $derived(source_entities.map((_, i) => {
+	let entity_highlights: string[] = $derived(source_entities.map((_, i) => {
 		if (hover_range && i >= hover_range[0] && i <= hover_range[1]) {
 			return 'bg-base-300'
 		}
@@ -40,6 +42,32 @@
 		[({ concept }) => !!concept, Concept],
 		[() => true, Punctuation],
 	]
+
+	let entity_context_menu_open = $state(false)
+	let entity_context_menu_data: EntityContextMenuData = $state({
+		entity_id: -1,
+		x: 0,
+		y: 0,
+	})
+
+	function open_entity_context_menu(event: any, entity_id: number) {
+		event.stopPropagation()
+		event.preventDefault()
+		entity_context_menu_data = {
+			entity_id,
+			x: event.clientX,
+			y: event.clientY,
+		}
+		entity_context_menu_open = true
+	}
+
+	function close_entity_context_menu(recalculate: boolean) {
+		entity_context_menu_open = false
+		if (recalculate) {
+			structure_entities(source_entities)
+			on_entity_select(null)
+		}
+	}
 
 	function entity_mouseover(i: number) {
 		hover_range = get_boundary_range(i)
@@ -82,12 +110,20 @@
 	{#each source_entities as entity}
 		{@const i = entity.id}
 		{@const Component = component_filters.find(([filter]) => filter(entity))?.[1]}
-		<div bind:this={entity_divs[i]} role="button" tabindex="0" class="cursor-default content-center h-20 {entity_highlights[i]}"
+		<div role="button" tabindex="0" class="id-{i} cursor-default content-center h-20 {entity_highlights[i]}"
 				onmouseenter={() => entity_mouseover(i)}
 				onfocus={() => entity_focus(i)}
 				onmouseleave={entity_mouseout}
-				onblur={() => {}} >
+				onblur={() => {}}
+				oncontextmenu={event => open_entity_context_menu(event, i)} >
 			<Component source_entity={entity} />
 		</div>
 	{/each}
+
+	{#if entity_context_menu_open}
+		<EntityContextMenu
+				bind:source_entities={source_entities}
+				data={entity_context_menu_data}
+				onclose={close_entity_context_menu} />
+	{/if}
 </div>

--- a/src/lib/edit/clipboard.svelte.ts
+++ b/src/lib/edit/clipboard.svelte.ts
@@ -1,0 +1,20 @@
+class EntityClipboard {
+	copied_entities: PageSourceEntity[] | null = $state.raw(null)
+
+	has_value() {
+		return !!this.copied_entities
+	}
+
+	copy(entities: PageSourceEntity[]) {
+		this.copied_entities = $state.snapshot(entities)
+	}
+
+	paste() {
+		const value = this.copied_entities
+		this.copied_entities = null
+		return value
+	}
+}
+
+
+export const entity_clipboard = new EntityClipboard()

--- a/src/lib/edit/index.d.ts
+++ b/src/lib/edit/index.d.ts
@@ -1,0 +1,6 @@
+
+type EntityContextMenuData = {
+	entity_id: number
+	x: number
+	y: number
+}

--- a/src/lib/encoding/semantic_encoding.ts
+++ b/src/lib/encoding/semantic_encoding.ts
@@ -1,7 +1,7 @@
 import type { D1Database } from '@cloudflare/workers-types'
 import { CATEGORY_ABBREVIATIONS, CATEGORY_NAME_LOOKUP, WORD_ENTITY_CATEGORIES } from './lookups'
 import { load_source_feature_map, load_target_feature_map, decode_features } from './features'
-import { is_boundary_end, is_boundary_start } from './entity_filters'
+import { structure_entities } from './structured'
 
 /**
  * The phase_2_encoding looks something like:
@@ -139,21 +139,7 @@ function encode_concept_data(entity: SourceEntity): { value: string } {
 
 export function structure_semantic_encoding(entities: SourceEntity[]): PageSourceEntity[] {
 	const new_entities: PageSourceEntity[] = entities.map((entity, i) => ({ ...entity, id: i, parent_id: -1, boundary_category: '' }))
-
-	const parent_id_stack: number[] = []
-	for (const [i, entity] of new_entities.entries()) {
-		entity.parent_id = parent_id_stack.at(-1) ?? -1
-
-		if (is_boundary_start(entity)) {
-			entity.boundary_category = entity.category_abbr
-			parent_id_stack.push(i)
-
-		} else if (is_boundary_end(entity)) {
-			entity.boundary_category = new_entities[entity.parent_id].boundary_category
-			parent_id_stack.pop()
-		}
-	}
-
+	structure_entities(new_entities)
 	return new_entities
 }
 

--- a/src/lib/encoding/structured.ts
+++ b/src/lib/encoding/structured.ts
@@ -1,0 +1,18 @@
+import { is_boundary_end, is_boundary_start } from './entity_filters'
+
+export function structure_entities(entities: PageSourceEntity[]) {
+	const parent_id_stack: number[] = []
+	for (const [i, entity] of entities.entries()) {
+		entity.id = i
+		entity.parent_id = parent_id_stack.at(-1) ?? -1
+
+		if (is_boundary_start(entity)) {
+			entity.boundary_category = entity.category_abbr
+			parent_id_stack.push(i)
+
+		} else if (is_boundary_end(entity)) {
+			entity.boundary_category = entities[entity.parent_id].boundary_category
+			parent_id_stack.pop()
+		}
+	}
+}

--- a/src/routes/[type]/[id_primary]/[id_secondary]/[id_tertiary]/edit/+page.svelte
+++ b/src/routes/[type]/[id_primary]/[id_secondary]/[id_tertiary]/edit/+page.svelte
@@ -1,10 +1,11 @@
 <script lang="ts">
 	import { PUBLIC_EDITOR_API_HOST } from '$env/static/public'
-	import { Navigation, SourceEntities } from '$lib'
+	import { Navigation } from '$lib'
 	import type { PageProps } from './$types'
 	import Settings from '$lib/settings/Settings.svelte'
 	import Sidebar from '$lib/sidebar_edit/Sidebar.svelte'
 	import Icon from '@iconify/svelte'
+	import SourceEntitiesEdit from '$lib/edit/SourceEntitiesEdit.svelte'
 
 	let { data }: PageProps = $props()
 
@@ -77,9 +78,9 @@
 	let selected_entity: PageSourceEntity|null = $state(null)
 	let sidebar_open = $state(false)
 
-	function on_entity_select(entity: PageSourceEntity) {
+	function on_entity_select(entity: PageSourceEntity|null) {
 		selected_entity = entity
-		sidebar_open = true
+		sidebar_open = !!entity
 	}
 
 	function on_sidebar_close() {
@@ -159,7 +160,7 @@
 	<div class="divider my-2"></div>
 	<div class="flex h-screen">
 		<div class="overflow-y-auto transition-all duration-300 flex-[1_1_auto]" style="margin-right: {sidebar_open ? '24rem' : '0'};">
-			<SourceEntities {source_entities} {selected_entity} {on_entity_select} />
+			<SourceEntitiesEdit bind:source_entities={source_entities} {selected_entity} {on_entity_select} />
 		</div>
 		{#if sidebar_open}
 			<Sidebar bind:entity={selected_entity} onclose={on_sidebar_close} {noun_list} {all_features} />


### PR DESCRIPTION
Resolves #33 and related to #35 .

Adds a right-click context menu for each entity, with Copy, Paste, Move, and Delete options.

https://github.com/user-attachments/assets/c0d11d17-d97c-46f0-ad28-12f29134e58d

When acted on a phrase or clause, everything within the phrase or clause is acted on as one. Nick and Lydia confirmed that this is intuitive and sufficient.