### PR TITLE
Chapter status rework

### DIFF
--- a/src/lib/EncodingStatus.svelte
+++ b/src/lib/EncodingStatus.svelte
@@ -1,0 +1,19 @@
+<script>
+	/** @type {{ status: SourceStatus, classes?: string }}*/
+	let { status, classes='' } = $props()
+
+	/** @type {Map<SourceStatus, string>}*/
+	const class_map = new Map([
+		['Ready to Translate', 'status-ready'],
+		['Final Review in Progress', 'status-review'],
+		['Initial Analysis Complete', 'status-initial-complete'],
+		['Initial Analysis in Progress', 'status-in-progress'],
+		['Not Started', 'status-not-started'],
+	])
+
+	let badge_class = $derived(class_map.get(status) || '')
+</script>
+
+<div class="badge {badge_class} {classes}">
+	{status}
+</div>

--- a/src/lib/app.css
+++ b/src/lib/app.css
@@ -88,3 +88,23 @@
 	color: whitesmoke;
 	background-color: #4c4c4c;
 }
+
+.status-ready {
+	background-color: #36b04b;
+}
+
+.status-review {
+	background-color: #dcf2cf;
+}
+
+.status-initial-complete {
+	background-color: #ffffe0;
+}
+
+.status-in-progress {
+	background-color: #c4e6f6;
+}
+
+.status-not-started {
+	background-color: #ddc9f0;
+}

--- a/src/lib/data/status.ts
+++ b/src/lib/data/status.ts
@@ -1,9 +1,18 @@
 import type { D1Database } from '@cloudflare/workers-types'
-import { get_primary_ids } from './read'
 
 export async function get_all_book_statuses(db: D1Database, type: string): Promise<StatusResult[]> {
-	const primary_ids = await get_primary_ids(db, type)
-	return await Promise.all(primary_ids.map(({ id_primary }) => get_book_status(db, { type, id_primary })))
+	const sql = `
+		SELECT status, id_primary
+		FROM ChapterStatus
+		WHERE type LIKE ?
+	`
+	const { results } = await db.prepare(sql).bind(type).all<{ status: SourceStatus, id_primary: string }>()
+	const by_book = Map.groupBy(results, result => result.id_primary)
+
+	return by_book.entries().map(([id_primary, statuses]) => ({
+		reference: { type, id_primary },
+		status: combine_statuses(statuses),
+	})).toArray()
 }
 
 export async function get_book_status(db: D1Database, reference: StatusRequestReference): Promise<StatusResult> {
@@ -15,8 +24,14 @@ export async function get_book_status(db: D1Database, reference: StatusRequestRe
 	`
 
 	const { results } = await db.prepare(sql).bind(reference.type, reference.id_primary).all<{ status: SourceStatus }>()
-	const chapter_statuses = results.map(({ status }) => status)
+	return {
+		reference,
+		status: combine_statuses(results)
+	}
+}
 
+function combine_statuses(status_array: { status: SourceStatus }[]) {
+	const just_statuses = status_array.map(({ status }) => status)
 	const status_mapping: [(statuses: SourceStatus[]) => boolean, SourceStatus][] = [
 		[statuses => statuses.every(s => s === 'Ready to Translate'), 'Ready to Translate'],
 		[statuses => statuses.every(s => s === 'Not Started'), 'Not Started'],
@@ -25,11 +40,22 @@ export async function get_book_status(db: D1Database, reference: StatusRequestRe
 		[statuses => statuses.some(s => s === 'Final Review in Progress'), 'Final Review in Progress'],
 		[() => true, 'Initial Analysis Complete'],
 	]
+	return just_statuses.length ? status_mapping.find(([predicate]) => predicate(just_statuses))![1] : 'Not Started'
+}
 
-	return {
-		reference,
-		status: chapter_statuses.length ? status_mapping.find(([predicate]) => predicate(chapter_statuses))![1] : 'Not Started',
-	}
+export async function get_chapter_statuses_for_book(db: D1Database, reference: StatusRequestReference): Promise<StatusResult[]> {
+	const sql = `
+		SELECT id_secondary, status
+		FROM ChapterStatus
+		WHERE type LIKE ?
+			AND id_primary LIKE ?
+	`
+
+	const { results } = await db.prepare(sql).bind(reference.type, reference.id_primary).all<{ id_secondary: string, status: SourceStatus }>()
+	return results.map(({ id_secondary, status }) => ({
+		reference: { ...reference, id_secondary },
+		status,
+	}))
 }
 
 export async function get_chapter_status(db: D1Database, reference: StatusRequestReference): Promise<StatusResult> {

--- a/src/lib/data/status.ts
+++ b/src/lib/data/status.ts
@@ -1,15 +1,6 @@
 import type { D1Database } from '@cloudflare/workers-types'
 import { get_primary_ids } from './read'
 
-interface StatusCountResult {
-	not_started_count: number
-	in_progress_count: number
-	initial_complete_count: number
-	review_count: number
-	ready_count: number
-	total_count: number
-}
-
 export async function get_all_book_statuses(db: D1Database, type: string): Promise<StatusResult[]> {
 	const primary_ids = await get_primary_ids(db, type)
 	return await Promise.all(primary_ids.map(({ id_primary }) => get_book_status(db, { type, id_primary })))
@@ -17,59 +8,46 @@ export async function get_all_book_statuses(db: D1Database, type: string): Promi
 
 export async function get_book_status(db: D1Database, reference: StatusRequestReference): Promise<StatusResult> {
 	const sql = `
-		SELECT
-			COUNT(*) FILTER (WHERE status = 'Not Started') AS not_started_count,
-			COUNT(*) FILTER (WHERE status = 'Initial Analysis in Progress') AS in_progress_count,
-			COUNT(*) FILTER (WHERE status = 'Initial Analysis Complete') AS initial_complete_count,
-			COUNT(*) FILTER (WHERE status = 'Final Review in Progress') AS review_count,
-			COUNT(*) FILTER (WHERE status = 'Ready to Translate') AS ready_count,
-			COUNT(*) AS total_count
-		FROM Sources
+		SELECT status
+		FROM ChapterStatus
 		WHERE type LIKE ?
 			AND id_primary LIKE ?
 	`
 
-	const result = await db.prepare(sql).bind(reference.type, reference.id_primary).first<StatusCountResult>()
+	const { results } = await db.prepare(sql).bind(reference.type, reference.id_primary).all<{ status: SourceStatus }>()
+	const chapter_statuses = results.map(({ status }) => status)
+
+	const status_mapping: [(statuses: SourceStatus[]) => boolean, SourceStatus][] = [
+		[statuses => statuses.every(s => s === 'Ready to Translate'), 'Ready to Translate'],
+		[statuses => statuses.every(s => s === 'Not Started'), 'Not Started'],
+		[statuses => statuses.some(s => s === 'Not Started'), 'Initial Analysis in Progress'],
+		[statuses => statuses.some(s => s === 'Initial Analysis in Progress'), 'Initial Analysis in Progress'],
+		[statuses => statuses.some(s => s === 'Final Review in Progress'), 'Final Review in Progress'],
+		[() => true, 'Initial Analysis Complete'],
+	]
+
 	return {
 		reference,
-		status: get_status_from_counts(result),
+		status: chapter_statuses.length ? status_mapping.find(([predicate]) => predicate(chapter_statuses))![1] : 'Not Started',
 	}
 }
 
 export async function get_chapter_status(db: D1Database, reference: StatusRequestReference): Promise<StatusResult> {
 	const sql = `
-		SELECT
-			COUNT(*) FILTER (WHERE status = 'Not Started') AS not_started_count,
-			COUNT(*) FILTER (WHERE status = 'Initial Analysis in Progress') AS in_progress_count,
-			COUNT(*) FILTER (WHERE status = 'Initial Analysis Complete') AS initial_complete_count,
-			COUNT(*) FILTER (WHERE status = 'Final Review in Progress') AS review_count,
-			COUNT(*) FILTER (WHERE status = 'Ready to Translate') AS ready_count,
-			COUNT(*) AS total_count
-		FROM Sources
+		SELECT status
+		FROM ChapterStatus
 		WHERE type LIKE ?
 			AND id_primary LIKE ?
 			AND id_secondary = ?
 	`
 
 	const prepared_statement = db.prepare(sql).bind(reference.type, reference.id_primary, reference.id_secondary!.toString())
-	const result = await prepared_statement.first<StatusCountResult>()
+	const result = await prepared_statement.first<{ status: SourceStatus }>()
+	
 	return {
 		reference,
-		status: get_status_from_counts(result),
+		status: result?.status ?? 'Not Started',
 	}
-}
-
-function get_status_from_counts(status_counts: StatusCountResult|null): SourceStatus {
-	const status_count_mapping: [(status_counts: StatusCountResult) => boolean, SourceStatus][] = [
-		[({ total_count, ready_count }) => total_count === ready_count, 'Ready to Translate'],
-		[({ total_count, not_started_count }) => total_count === not_started_count, 'Not Started'],
-		[({ not_started_count }) => not_started_count > 0, 'Initial Analysis in Progress'],
-		[({ in_progress_count }) => in_progress_count > 0, 'Initial Analysis in Progress'],
-		[({ review_count }) => review_count > 0, 'Final Review in Progress'],
-		[() => true, 'Initial Analysis Complete'],
-	]
-
-	return status_counts ? status_count_mapping.find(([predicate]) => predicate(status_counts))![1] : 'Not Started'
 }
 
 export async function get_verse_statuses(db: D1Database, references: Reference[]): Promise<StatusResult[]> {

--- a/src/routes/lookup/status/[type]/+page.svelte
+++ b/src/routes/lookup/status/[type]/+page.svelte
@@ -1,5 +1,7 @@
 <script>
 	import { status_list } from '$lib/data/lookups.js'
+	import EncodingStatus from '$lib/EncodingStatus.svelte'
+	import Icon from '@iconify/svelte'
 
 	const { data } = $props()
 
@@ -26,16 +28,24 @@
 	</select>
 </div>
 
-<div class="flex py-3 gap-7">
+<div class="flex flex-col md:flex-row py-3 gap-7">
 	{#each filtered_status_groups as { group_name, statuses }}
-		<div class="flex-auto">
+		<div class="w-full md:flex-auto">
 			<table class="table table-zebra">
 				<thead><tr><th>{group_name}</th></tr></thead>
 				<tbody>
-					{#each statuses as { reference: { id_primary }, status }}
+					{#each statuses as { reference: { type, id_primary }, status }}
 						<tr>
 							<th>{id_primary}</th>
-							<td>{status}</td>
+							<td>
+								<EncodingStatus {status} />
+							</td>
+							<td>
+								<a href="/lookup/status/{type}/{id_primary}" class="link flex">
+									Chapter details
+									<Icon icon="fe:link-external" class="h-4 w-4 mt-1" />
+								</a>
+							</td>
 						</tr>
 					{/each}
 				</tbody>

--- a/src/routes/lookup/status/[type]/[id_primary]/+page.server.js
+++ b/src/routes/lookup/status/[type]/[id_primary]/+page.server.js
@@ -1,0 +1,15 @@
+import { get_book_status, get_chapter_statuses_for_book } from '$lib/data/status'
+
+/** @type {import('./$types').PageServerLoad} */
+export async function load({ locals: { db }, params: { type, id_primary } }) {
+	/** @type {StatusRequestReference} */
+	const reference = { type, id_primary }
+
+	const book_status = await get_book_status(db, reference)
+	const chapter_statuses = await get_chapter_statuses_for_book(db, reference)
+
+	return {
+		book_status,
+		chapter_statuses,
+	}
+}

--- a/src/routes/lookup/status/[type]/[id_primary]/+page.svelte
+++ b/src/routes/lookup/status/[type]/[id_primary]/+page.svelte
@@ -1,0 +1,47 @@
+<script>
+	import EncodingStatus from '$lib/EncodingStatus.svelte'
+
+	const { data } = $props()
+
+	const book_status = data.book_status
+	const chapter_statuses = data.chapter_statuses
+
+	let statuses_present = $derived(new Set(chapter_statuses.map(s => s.status)))
+
+	let selected_status = $state('All')
+	let filtered_chapters = $derived(selected_status === 'All' ? chapter_statuses : chapter_statuses.filter(s => s.status === selected_status))
+</script>
+
+<div class="prose mb-5">
+	<h2>Encoding Status - {book_status.reference.id_primary}</h2>
+	<p><EncodingStatus status={book_status.status} /></p>
+</div>
+
+<div>
+	<div class="prose">
+		<h3>Chapters</h3>
+	</div>
+
+	{#if statuses_present.size > 1}
+		<div class="my-3">
+			Status
+			<select class="select" bind:value={selected_status}>
+				<option value="All" selected>All</option>
+				{#each statuses_present as status}
+					<option value={status}>{status}</option>
+				{/each}
+			</select>
+		</div>
+	{/if}
+
+	<div class="flex flex-wrap py-3 gap-3">
+		{#each filtered_chapters as { reference, status }}
+			<div class="card flex-none w-45 bg-base-100 card-xs shadow-sm">
+				<div class="card-body">
+					<h2 class="card-title">{reference.id_secondary}</h2>
+					<p><EncodingStatus {status} classes="badge-sm" /></p>
+				</div>
+			</div>
+		{/each}
+	</div>
+</div>


### PR DESCRIPTION
Used the new ChapterStatus table to more quickly calculate and load the book statuses.

Also added color to the statuses, and added a link on the book status page to view the breakdown of each individual chapter.
<img width="1484" height="508" alt="image" src="https://github.com/user-attachments/assets/84a2dfeb-4468-4fda-9d55-741328b34180" />

Here is the chapter status page:
<img width="1402" height="724" alt="image" src="https://github.com/user-attachments/assets/712bce86-6836-4739-b44f-4ffc532548f7" />

This is particularly helpful for the Psalms, where you can filter to show only the Psalms that are ready to be translated (for example).
<img width="1404" height="362" alt="image" src="https://github.com/user-attachments/assets/202bbe0d-07f3-4ce1-8e9d-996c76dafa71" />

It might be nice to include a query parameter in the url with the status filter to apply, but I don't remember how to do that dynamically with svelte, where it doesn't have to fully reload the page.