### PR TITLE
Add ability to insert entities

### DIFF
--- a/src/lib/edit/InsertEntityContextMenu.svelte
+++ b/src/lib/edit/InsertEntityContextMenu.svelte
@@ -1,7 +1,10 @@
 <script lang="ts">
 	import { is_boundary_start } from '$lib/encoding/entity_filters'
+	import ConceptDialog from '$lib/ConceptDialog.svelte'
 	import { entity_clipboard } from './clipboard.svelte'
 	import { DEFAULTS } from './default_entities'
+	import { page } from '$app/state'
+	import { fill_in_features } from '$lib/encoding/features'
 
 	interface Props {
 		source_entities: PageSourceEntity[]
@@ -10,9 +13,21 @@
 	}
 	let { source_entities = $bindable(), data, onclose }: Props = $props()
 
-	let submenu: string | null = $state(null)
+	let submenu = $state<string | null>(null)
 
-	function insert_before(entity: PageSourceEntity) {
+	let parent = $derived.by(() => {
+		const entity = source_entities[data.entity_id]
+		if (!entity || entity.parent_id === -1) {
+			return null
+		}
+		return source_entities[entity.parent_id] || null
+	})
+
+	function insert_entity(entity: PageSourceEntity) {
+		const { feature_codes, features } = fill_in_features(entity, page.data.features as FeatureMap)
+		entity.feature_codes = feature_codes
+		entity.features = features
+		
 		if (is_boundary_start(entity)) {
 			const end_map: Record<string, string> = {
 				'{': '}',
@@ -35,11 +50,27 @@
 		}
 	}
 
-	function paste_before() {
+	function paste_entity() {
 		const new_entities = entity_clipboard.paste()
 		if (new_entities !== null) {
 			source_entities.splice(data.entity_id, 0, ...new_entities)
 			onclose(true, data.entity_id)
+		} else {
+			onclose(false)
+		}
+	}
+	
+	let dialog_open = $state(false)
+	let new_concept_entity = $state<PageSourceEntity | null>(null)
+	function open_concept_dialog(entity: PageSourceEntity) {
+		new_concept_entity = entity
+		dialog_open = true
+	}
+	function close_concept_dialog() {
+		dialog_open = false
+
+		if (new_concept_entity?.concept?.stem) {
+			insert_entity(new_concept_entity)
 		} else {
 			onclose(false)
 		}
@@ -50,40 +81,79 @@
 <!-- svelte-ignore a11y_no_static_element_interactions -->
 <div class="card shadow-lg bg-base-100 min-w-50" style="position: fixed; left: {data.x}px; top: {data.y}px; z-index: 60;"
 		onclick={e => e.stopPropagation()}
-		onmouseleave={() => onclose(false)}>
+		onmouseleave={() => !dialog_open && onclose(false)}>
 	<ul class="menu w-full">
 		{#if entity_clipboard.has_value()}
-			<li><button onclick={paste_before}>Paste</button></li>
+			<li><button onclick={paste_entity}>Paste</button></li>
 		{/if}
-		<li>
-			<div class="relative" onmouseenter={() => submenu = 'clause'}>
-				<button>Clause</button>
-				{#if submenu === 'clause'}
-					<div class="card bg-base-100 min-w-50 shadow p-2 absolute left-full top-0 ml-2">
-						<ul>
-							<li><button onclick={() => insert_before(DEFAULTS.CLAUSE_MAIN)}>Main Clause</button></li>
-							<li><button onclick={() => insert_before(DEFAULTS.CLAUSE_SUBORDINATE)}>Subordinate Clause</button></li>
-							<li><button onclick={() => insert_before(DEFAULTS.CLAUSE_RELATIVE)}>Relative Clause</button></li>
-							<li><button onclick={() => insert_before(DEFAULTS.CLAUSE_PATIENT)}>Patient Clause</button></li>
-						</ul>
-					</div>
-				{/if}
-			</div>
-		</li>
-		<li>
-			<div class="relative" onmouseenter={() => submenu = 'phrase'}>
-				<button>Phrase</button>
-				{#if submenu === 'phrase'}
-					<div class="card bg-base-100 min-w-50 shadow p-2 absolute left-full top-0 ml-2">
-						<ul>
-							<li><button onclick={() => insert_before(DEFAULTS.NOUN_PHRASE)}>Noun Phrase</button></li>
-							<li><button onclick={() => insert_before(DEFAULTS.VERB_PHRASE)}>Verb Phrase</button></li>
-							<li><button onclick={() => insert_before(DEFAULTS.ADJECTIVE_PHRASE)}>Adjective Phrase</button></li>
-							<li><button onclick={() => insert_before(DEFAULTS.ADVERB_PHRASE)}>Adverb Phrase</button></li>
-						</ul>
-					</div>
-				{/if}
-			</div>
-		</li>
+		{#if !parent || ['Clause', 'Noun Phrase', 'Adjective Phrase'].includes(parent.category)}
+			<li>
+				<div class="relative" onmouseenter={() => submenu = 'clause'}>
+					<button>Clause</button>
+					{#if submenu === 'clause'}
+						<div class="card bg-base-100 min-w-50 shadow p-2 absolute left-full top-0 ml-2">
+							<ul>
+								{#if !parent}
+									<li><button onclick={() => insert_entity(DEFAULTS.CLAUSE_MAIN)}>Main Clause</button></li>
+								{:else if parent.category === 'Clause'}
+									<li><button onclick={() => insert_entity(DEFAULTS.CLAUSE_ADVERBIAL)}>Adverbial Clause</button></li>
+									<li><button onclick={() => insert_entity(DEFAULTS.CLAUSE_PATIENT)}>Patient (Object Complement)</button></li>
+									<li><button onclick={() => insert_entity(DEFAULTS.CLAUSE_AGENT)}>Agent (Subject Complement)</button></li>
+									<li><button onclick={() => insert_entity(DEFAULTS.CLAUSE_CLOSE_QUOTE)}>Closing Quotation Frame</button></li>
+								{:else if parent.category === 'Noun Phrase'}
+									<li><button onclick={() => insert_entity(DEFAULTS.CLAUSE_RELATIVE)}>Relative Clause</button></li>
+								{:else if parent.category === 'Adjective Phrase'}
+									<li><button onclick={() => insert_entity(DEFAULTS.CLAUSE_ADJ_PATIENT)}>Adjectival Complement</button></li>
+								{/if}
+							</ul>
+						</div>
+					{/if}
+				</div>
+			</li>
+		{/if}
+		{#if parent}
+			<li>
+				<div class="relative" onmouseenter={() => submenu = 'phrase'}>
+					<button>Phrase</button>
+					{#if submenu === 'phrase'}
+						<div class="card bg-base-100 min-w-50 shadow p-2 absolute left-full top-0 ml-2">
+							<ul>
+								<li><button onclick={() => insert_entity(DEFAULTS.NOUN_PHRASE)}>Noun Phrase</button></li>
+								<li><button onclick={() => insert_entity(DEFAULTS.VERB_PHRASE)}>Verb Phrase</button></li>
+								{#if parent.category === 'Clause'}
+									<li><button onclick={() => insert_entity(DEFAULTS.ADJECTIVE_PHRASE_PREDICATIVE)}>Adjective Phrase</button></li>
+								{:else}
+									<li><button onclick={() => insert_entity(DEFAULTS.ADJECTIVE_PHRASE)}>Adjective Phrase</button></li>
+								{/if}
+								<li><button onclick={() => insert_entity(DEFAULTS.ADVERB_PHRASE)}>Adverb Phrase</button></li>
+							</ul>
+						</div>
+					{/if}
+				</div>
+			</li>
+			<li>
+				<div class="relative" onmouseenter={() => submenu = 'concept'}>
+					<button>Concept</button>
+					{#if submenu === 'concept'}
+						<div class="card bg-base-100 min-w-50 shadow p-2 absolute left-full top-0 ml-2">
+							<ul>
+								<li><button onclick={() => open_concept_dialog(DEFAULTS.NOUN)}>Noun</button></li>
+								<li><button onclick={() => open_concept_dialog(DEFAULTS.VERB)}>Verb</button></li>
+								<li><button onclick={() => open_concept_dialog(DEFAULTS.ADJECTIVE)}>Adjective</button></li>
+								<li><button onclick={() => open_concept_dialog(DEFAULTS.ADVERB)}>Adverb</button></li>
+								<li><button onclick={() => open_concept_dialog(DEFAULTS.ADPOSITION)}>Adposition</button></li>
+								<li><button onclick={() => open_concept_dialog(DEFAULTS.CONJUNCTION)}>Conjunction</button></li>
+								<li><button onclick={() => open_concept_dialog(DEFAULTS.PARTICLE)}>Particle</button></li>
+								<li><button onclick={() => open_concept_dialog(DEFAULTS.PHRASAL)}>Phrasal</button></li>
+							</ul>
+						</div>
+					{/if}
+				</div>
+			</li>
+		{/if}
 	</ul>
 </div>
+
+{#if dialog_open && !!new_concept_entity?.concept}
+	<ConceptDialog bind:concept={new_concept_entity.concept} onclose={close_concept_dialog} />
+{/if}

--- a/src/lib/edit/InsertEntityContextMenu.svelte
+++ b/src/lib/edit/InsertEntityContextMenu.svelte
@@ -5,6 +5,7 @@
 	import { DEFAULTS } from './default_entities'
 	import { page } from '$app/state'
 	import { fill_in_features } from '$lib/encoding/features'
+    import Page from '../../routes/+page.svelte';
 
 	interface Props {
 		source_entities: PageSourceEntity[]
@@ -40,8 +41,12 @@
 				value: end_map[entity.value],
 				boundary_category: entity.boundary_category,
 			}
+			if (parent) {
+				source_entities.splice(data.entity_id, 0, entity, end_entity)
+			} else {
+				source_entities.splice(data.entity_id, 0, entity, DEFAULTS.PERIOD, end_entity)
+			}
 
-			source_entities.splice(data.entity_id, 0, entity, end_entity)
 			onclose(true, data.entity_id)
 
 		} else {

--- a/src/lib/edit/InsertEntityContextMenu.svelte
+++ b/src/lib/edit/InsertEntityContextMenu.svelte
@@ -1,0 +1,89 @@
+<script lang="ts">
+	import { is_boundary_start } from '$lib/encoding/entity_filters'
+	import { entity_clipboard } from './clipboard.svelte'
+	import { DEFAULTS } from './default_entities'
+
+	interface Props {
+		source_entities: PageSourceEntity[]
+		data: EntityContextMenuData
+		onclose: (recalculate: boolean, id_to_select?: number) => void
+	}
+	let { source_entities = $bindable(), data, onclose }: Props = $props()
+
+	let submenu: string | null = $state(null)
+
+	function insert_before(entity: PageSourceEntity) {
+		if (is_boundary_start(entity)) {
+			const end_map: Record<string, string> = {
+				'{': '}',
+				'[': ']',
+				'(': ')',
+			}
+
+			const end_entity: PageSourceEntity = {
+				...DEFAULTS.EMPTY,
+				value: end_map[entity.value],
+				boundary_category: entity.boundary_category,
+			}
+
+			source_entities.splice(data.entity_id, 0, entity, end_entity)
+			onclose(true, data.entity_id)
+
+		} else {
+			source_entities.splice(data.entity_id, 0, entity)
+			onclose(true, data.entity_id)
+		}
+	}
+
+	function paste_before() {
+		const new_entities = entity_clipboard.paste()
+		if (new_entities !== null) {
+			source_entities.splice(data.entity_id, 0, ...new_entities)
+			onclose(true, data.entity_id)
+		} else {
+			onclose(false)
+		}
+	}
+</script>
+
+<!-- svelte-ignore a11y_click_events_have_key_events -->
+<!-- svelte-ignore a11y_no_static_element_interactions -->
+<div class="card shadow-lg bg-base-100 min-w-50" style="position: fixed; left: {data.x}px; top: {data.y}px; z-index: 60;"
+		onclick={e => e.stopPropagation()}
+		onmouseleave={() => onclose(false)}>
+	<ul class="menu w-full">
+		{#if entity_clipboard.has_value()}
+			<li><button onclick={paste_before}>Paste</button></li>
+		{/if}
+		<li>
+			<div class="relative" onmouseenter={() => submenu = 'clause'}>
+				<button>Clause</button>
+				{#if submenu === 'clause'}
+					<div class="card bg-base-100 min-w-50 shadow p-2 absolute left-full top-0 ml-2">
+						<ul>
+							<li><button onclick={() => insert_before(DEFAULTS.CLAUSE_MAIN)}>Main Clause</button></li>
+							<li><button onclick={() => insert_before(DEFAULTS.CLAUSE_SUBORDINATE)}>Subordinate Clause</button></li>
+							<li><button onclick={() => insert_before(DEFAULTS.CLAUSE_RELATIVE)}>Relative Clause</button></li>
+							<li><button onclick={() => insert_before(DEFAULTS.CLAUSE_PATIENT)}>Patient Clause</button></li>
+						</ul>
+					</div>
+				{/if}
+			</div>
+		</li>
+		<li>
+			<div class="relative" onmouseenter={() => submenu = 'phrase'}>
+				<button>Phrase</button>
+				{#if submenu === 'phrase'}
+					<div class="card bg-base-100 min-w-50 shadow p-2 absolute left-full top-0 ml-2">
+						<ul>
+							<li><button onclick={() => insert_before(DEFAULTS.NOUN_PHRASE)}>Noun Phrase</button></li>
+							<li><button onclick={() => insert_before(DEFAULTS.VERB_PHRASE)}>Verb Phrase</button></li>
+							<li><button onclick={() => insert_before(DEFAULTS.ADJECTIVE_PHRASE)}>Adjective Phrase</button></li>
+							<li><button onclick={() => insert_before(DEFAULTS.ADVERB_PHRASE)}>Adverb Phrase</button></li>
+						</ul>
+					</div>
+				{/if}
+			</div>
+		</li>
+	</ul>
+</div>

--- a/src/lib/edit/InsertEntityContextMenu.svelte
+++ b/src/lib/edit/InsertEntityContextMenu.svelte
@@ -151,6 +151,24 @@
 				</div>
 			</li>
 		{/if}
+		{#if !parent || parent.category === 'Clause'}
+			<li>
+				<div class="relative" onmouseenter={() => submenu = 'other'}>
+					<button>Other</button>
+					{#if submenu === 'other'}
+						<div class="card bg-base-100 min-w-50 shadow p-2 absolute left-full top-0 ml-2">
+							<ul>
+								{#if !parent}
+									<li><button onclick={() => insert_entity(DEFAULTS.PARAGRAPH)}>paragraph</button></li>
+								{:else if parent.category === 'Clause'}
+									<li><button onclick={() => insert_entity(DEFAULTS.PERIOD)}>period</button></li>
+								{/if}
+							</ul>
+						</div>
+					{/if}
+				</div>
+			</li>
+		{/if}
 	</ul>
 </div>
 

--- a/src/lib/edit/SourceEntitiesEdit.svelte
+++ b/src/lib/edit/SourceEntitiesEdit.svelte
@@ -3,8 +3,9 @@
 	import BoundaryEnd from '../entity_displays/BoundaryEnd.svelte'
 	import BoundaryStart from '../entity_displays/BoundaryStart.svelte'
 	import Punctuation from '../entity_displays/Punctuation.svelte'
-	import { is_boundary_end, is_boundary_start } from '$lib/encoding/entity_filters'
 	import EntityContextMenu from './EntityContextMenu.svelte'
+	import InsertEntityContextMenu from './InsertEntityContextMenu.svelte'
+	import { is_boundary_end, is_boundary_start } from '$lib/encoding/entity_filters'
 	import { structure_entities } from '$lib/encoding/structured'
 
 	type IndexRange = [number, number]
@@ -15,8 +16,6 @@
 		on_entity_select: (entity: PageSourceEntity|null) => void
 	}
 	let { source_entities = $bindable(), selected_entity, on_entity_select }: Props = $props()
-
-	// let entity_divs: HTMLElement[] = $state([])
 
 	let hover_range: IndexRange | null = $state(null)
 	let select_range: IndexRange | null = $derived(
@@ -43,8 +42,8 @@
 		[() => true, Punctuation],
 	]
 
-	let entity_context_menu_open = $state(false)
 	let entity_context_menu_data: EntityContextMenuData = $state({
+		is_open: false,
 		entity_id: -1,
 		x: 0,
 		y: 0,
@@ -54,15 +53,43 @@
 		event.stopPropagation()
 		event.preventDefault()
 		entity_context_menu_data = {
+			is_open: true,
 			entity_id,
 			x: event.clientX,
 			y: event.clientY,
 		}
-		entity_context_menu_open = true
 	}
 
 	function close_entity_context_menu(recalculate: boolean, id_to_select?: number) {
-		entity_context_menu_open = false
+		entity_context_menu_data.is_open = false
+		close_context_menu(recalculate, id_to_select)
+	}
+
+	let insert_context_menu_data: EntityContextMenuData = $state({
+		is_open: false,
+		entity_id: -1,
+		x: 0,
+		y: 0,
+	})
+
+	function open_insert_context_menu(event: any, entity_id: number) {
+		event.stopPropagation()
+		event.preventDefault()
+		insert_context_menu_data = {
+			is_open: true,
+			entity_id,
+			x: event.clientX,
+			y: event.clientY,
+		}
+	}
+
+	function close_insert_context_menu(recalculate: boolean, id_to_select?: number) {
+		insert_context_menu_data.is_open = false
+		insert_context_menu_data.entity_id = -1
+		close_context_menu(recalculate, id_to_select)
+	}
+
+	function close_context_menu(recalculate: boolean, id_to_select?: number) {
 		if (recalculate) {
 			structure_entities(source_entities)
 			if (id_to_select) {
@@ -108,12 +135,25 @@
 			return [i, i]
 		}
 	}
+
+	function insert_button_in_range(i: number, range: IndexRange|null) {
+		return !!range?.length && (i > range[0] && i <= range[range.length - 1])
+	}
 </script>
 
 <div class="inline-flex flex-wrap py-3">
 	{#each source_entities as entity}
 		{@const i = entity.id}
 		{@const Component = component_filters.find(([filter]) => filter(entity))?.[1]}
+
+		<div class="{insert_button_in_range(i, hover_range) || insert_button_in_range(i, select_range) ? entity_highlights[i] : ''}">
+			<button class="btn btn-xs mt-4 h-12 w-4 text-lg {insert_context_menu_data.entity_id === i ? "opacity-100" : "opacity-0"} hover:opacity-100 transition-opacity duration-150"
+				onclick={e => open_insert_context_menu(e, i)}
+				aria-label="Insert Constituent">
+				+
+			</button>
+		</div>
+
 		<div role="button" tabindex="0" class="id-{i} cursor-pointer content-center h-20 {entity_highlights[i]}"
 				onclick={() => entity_focus(i)}
 				onkeydown={e => (e.key === 'Enter' || e.key === ' ') && entity_focus(i)}
@@ -121,12 +161,20 @@
 				onfocus={() => entity_focus(i)}
 				onmouseleave={entity_mouseout}
 				onblur={() => {}}
-				oncontextmenu={event => open_entity_context_menu(event, i)} >
+				onclick={e => open_entity_context_menu(e, i)}
+				onkeydown={(e) => (e.key === 'Enter' || e.key === ' ') && open_entity_context_menu(e, i)}>
 			<Component source_entity={entity} />
 		</div>
 	{/each}
 
-	{#if entity_context_menu_open}
+	{#if insert_context_menu_data.is_open}
+		<InsertEntityContextMenu
+				bind:source_entities={source_entities}
+				data={insert_context_menu_data}
+				onclose={close_insert_context_menu} />
+	{/if}
+
+	{#if entity_context_menu_data.is_open}
 		<EntityContextMenu
 				bind:source_entities={source_entities}
 				data={entity_context_menu_data}

--- a/src/lib/edit/SourceEntitiesEdit.svelte
+++ b/src/lib/edit/SourceEntitiesEdit.svelte
@@ -161,22 +161,21 @@
 				onfocus={() => entity_focus(i)}
 				onmouseleave={entity_mouseout}
 				onblur={() => {}}
-				onclick={e => open_entity_context_menu(e, i)}
-				onkeydown={(e) => (e.key === 'Enter' || e.key === ' ') && open_entity_context_menu(e, i)}>
+				oncontextmenu={event => open_entity_context_menu(event, i)}>
 			<Component source_entity={entity} />
 		</div>
 	{/each}
 
 	{#if insert_context_menu_data.is_open}
 		<InsertEntityContextMenu
-				bind:source_entities={source_entities}
+				bind:source_entities
 				data={insert_context_menu_data}
 				onclose={close_insert_context_menu} />
 	{/if}
 
 	{#if entity_context_menu_data.is_open}
 		<EntityContextMenu
-				bind:source_entities={source_entities}
+				bind:source_entities
 				data={entity_context_menu_data}
 				onclose={close_entity_context_menu} />
 	{/if}

--- a/src/lib/edit/SourceEntitiesEdit.svelte
+++ b/src/lib/edit/SourceEntitiesEdit.svelte
@@ -141,22 +141,25 @@
 	}
 </script>
 
+{#snippet insert_button(i: number)}
+	<button class="btn btn-xs mt-4 h-12 w-4 text-lg {insert_context_menu_data.entity_id === i ? "opacity-100" : "opacity-0"} focus:opacity-100 hover:opacity-100 transition-opacity duration-150"
+		onclick={e => open_insert_context_menu(e, i)}
+		aria-label="Insert Constituent">
+		+
+	</button>
+{/snippet}
+
 <div class="inline-flex flex-wrap py-3">
 	{#each source_entities as entity}
 		{@const i = entity.id}
 		{@const Component = component_filters.find(([filter]) => filter(entity))?.[1]}
 
 		<div class="{insert_button_in_range(i, hover_range) || insert_button_in_range(i, select_range) ? entity_highlights[i] : ''}">
-			<button class="btn btn-xs mt-4 h-12 w-4 text-lg {insert_context_menu_data.entity_id === i ? "opacity-100" : "opacity-0"} hover:opacity-100 transition-opacity duration-150"
-				onclick={e => open_insert_context_menu(e, i)}
-				aria-label="Insert Constituent">
-				+
-			</button>
+			{@render insert_button(i)}
 		</div>
 
 		<div role="button" tabindex="0" class="id-{i} cursor-pointer content-center h-20 {entity_highlights[i]}"
-				onclick={() => entity_focus(i)}
-				onkeydown={e => (e.key === 'Enter' || e.key === ' ') && entity_focus(i)}
+				onkeydown={e => e.key === 'Enter' && entity_focus(i)}
 				onmouseenter={() => entity_mouseover(i)}
 				onfocus={() => entity_focus(i)}
 				onmouseleave={entity_mouseout}
@@ -165,6 +168,10 @@
 			<Component source_entity={entity} />
 		</div>
 	{/each}
+
+	<div>
+		{@render insert_button(source_entities.length)}
+	</div>
 
 	{#if insert_context_menu_data.is_open}
 		<InsertEntityContextMenu

--- a/src/lib/edit/default_entities.ts
+++ b/src/lib/edit/default_entities.ts
@@ -30,6 +30,18 @@ const default_subordinate_clause: PageSourceEntity = {
 	category: 'Clause',
 	category_abbr: 'C',
 	value: '[',
+	boundary_category: 'C',
+}
+
+const default_agent_clause: PageSourceEntity = {
+	...default_subordinate_clause,
+	features: [
+		{ name: 'Type', value: 'Agent (Subject Complement)' },
+	],
+}
+
+const default_adverbial_clause: PageSourceEntity = {
+	...default_subordinate_clause,
 	features: [
 		{ name: 'Type', value: 'Event Modifier (Adverbial Clause)' },
 	],
@@ -49,12 +61,25 @@ const default_patient_clause: PageSourceEntity = {
 	],
 }
 
+const default_adj_patient_clause: PageSourceEntity = {
+	...default_subordinate_clause,
+	features: [
+		{ name: 'Type', value: 'Attributive Patient (Adjectival Object Complement)' },
+	],
+}
+
+const default_close_quote_clause: PageSourceEntity = {
+	...default_subordinate_clause,
+	features: [
+		{ name: 'Type', value: 'Closing Quotation Frame' },
+	],
+}
+
 const default_np: PageSourceEntity = {
 	...defaults,
 	category: 'Noun Phrase',
 	category_abbr: 'NP',
 	value: '(',
-	feature_codes: 'N',	// for 'Not Applicable'
 	features: [
 		{ name: 'Semantic Role', value: 'Not Applicable' },
 	],
@@ -77,6 +102,17 @@ const default_adjp: PageSourceEntity = {
 	boundary_category: 'NP',
 }
 
+const default_adjp_predicative: PageSourceEntity = {
+	...defaults,
+	category: 'Adjective Phrase',
+	category_abbr: 'AdjP',
+	value: '(',
+	boundary_category: 'NP',
+	features: [
+		{ name: 'Usage', value: 'Predicative' },
+	],
+}
+
 const default_advp: PageSourceEntity = {
 	...defaults,
 	category: 'Adverb Phrase',
@@ -85,14 +121,92 @@ const default_advp: PageSourceEntity = {
 	boundary_category: 'NP',
 }
 
+const default_noun: PageSourceEntity = {
+	...defaults,
+	category: 'Noun',
+	category_abbr: 'N',
+	features: [
+		{ name: 'Participant Tracking', value: 'Routine' },
+		{ name: 'Specificity', value: 'Specific' },
+		{ name: 'Person', value: 'Third' },
+	],
+	concept: { stem: '', sense: '', part_of_speech: 'Noun' },
+}
+
+const default_verb: PageSourceEntity = {
+	...defaults,
+	category: 'Verb',
+	category_abbr: 'V',
+	features: [
+		{ name: 'Time', value: 'Discourse' },
+		{ name: 'Aspect', value: 'Unmarked' },
+	],
+	concept: { stem: '', sense: '', part_of_speech: 'Verb' },
+}
+
+const default_adjective: PageSourceEntity = {
+	...defaults,
+	category: 'Adjective',
+	category_abbr: 'Adj',
+	concept: { stem: '', sense: '', part_of_speech: 'Adjective' },
+}
+
+const default_adverb: PageSourceEntity = {
+	...defaults,
+	category: 'Adverb',
+	category_abbr: 'Adv',
+	concept: { stem: '', sense: '', part_of_speech: 'Adverb' },
+}
+
+const default_adposition: PageSourceEntity = {
+	...defaults,
+	category: 'Adposition',
+	category_abbr: 'Adp',
+	concept: { stem: '', sense: '', part_of_speech: 'Adposition' },
+}
+
+const default_conjunction: PageSourceEntity = {
+	...defaults,
+	category: 'Conjunction',
+	category_abbr: 'Con',
+	concept: { stem: '', sense: '', part_of_speech: 'Conjunction' },
+}
+
+const default_particle: PageSourceEntity = {
+	...defaults,
+	category: 'Particle',
+	category_abbr: 'Par',
+	concept: { stem: '', sense: '', part_of_speech: 'Particle' },
+}
+
+const default_phrasal: PageSourceEntity = {
+	...defaults,
+	category: 'Phrasal',
+	category_abbr: 'Phr',
+	concept: { stem: '', sense: '', part_of_speech: 'Phrasal' },
+}
+
 export const DEFAULTS = {
 	EMPTY: defaults,
 	CLAUSE_MAIN: default_main_clause,
 	CLAUSE_SUBORDINATE: default_subordinate_clause,
 	CLAUSE_RELATIVE: default_relative_clause,
+	CLAUSE_AGENT: default_agent_clause,
 	CLAUSE_PATIENT: default_patient_clause,
+	CLAUSE_ADVERBIAL: default_adverbial_clause,
+	CLAUSE_ADJ_PATIENT: default_adj_patient_clause,
+	CLAUSE_CLOSE_QUOTE: default_close_quote_clause,
 	NOUN_PHRASE: default_np,
 	VERB_PHRASE: default_vp,
 	ADJECTIVE_PHRASE: default_adjp,
+	ADJECTIVE_PHRASE_PREDICATIVE: default_adjp_predicative,
 	ADVERB_PHRASE: default_advp,
+	NOUN: default_noun,
+	VERB: default_verb,
+	ADJECTIVE: default_adjective,
+	ADVERB: default_adverb,
+	ADPOSITION: default_adposition,
+	CONJUNCTION: default_conjunction,
+	PHRASAL: default_phrasal,
+	PARTICLE: default_particle,
 }

--- a/src/lib/edit/default_entities.ts
+++ b/src/lib/edit/default_entities.ts
@@ -1,0 +1,98 @@
+
+const defaults: PageSourceEntity = {
+	category: '',
+	category_abbr: '',
+	value: '',
+	features: [],
+	feature_codes: '',
+	noun_list_index: null,
+	concept: null,
+	pairing_concept: null,
+	pairing_type: '',
+	id: -1,
+	parent_id: -1,
+	boundary_category: '',
+}
+
+const default_main_clause: PageSourceEntity = {
+	...defaults,
+	category: 'Clause',
+	category_abbr: 'C',
+	value: '{',
+	features: [
+		{ name: 'Type', value: 'Independent' },
+	],
+	boundary_category: 'C',
+}
+
+const default_subordinate_clause: PageSourceEntity = {
+	...defaults,
+	category: 'Clause',
+	category_abbr: 'C',
+	value: '[',
+	features: [
+		{ name: 'Type', value: 'Event Modifier (Adverbial Clause)' },
+	],
+}
+
+const default_relative_clause: PageSourceEntity = {
+	...default_subordinate_clause,
+	features: [
+		{ name: 'Type', value: 'Restrictive Thing Modifier (Relative Clause)' },
+	],
+}
+
+const default_patient_clause: PageSourceEntity = {
+	...default_subordinate_clause,
+	features: [
+		{ name: 'Type', value: 'Patient (Object Complement)' },
+	],
+}
+
+const default_np: PageSourceEntity = {
+	...defaults,
+	category: 'Noun Phrase',
+	category_abbr: 'NP',
+	value: '(',
+	feature_codes: 'N',	// for 'Not Applicable'
+	features: [
+		{ name: 'Semantic Role', value: 'Not Applicable' },
+	],
+	boundary_category: 'NP',
+}
+
+const default_vp: PageSourceEntity = {
+	...defaults,
+	category: 'Verb Phrase',
+	category_abbr: 'VP',
+	value: '(',
+	boundary_category: 'NP',
+}
+
+const default_adjp: PageSourceEntity = {
+	...defaults,
+	category: 'Adjective Phrase',
+	category_abbr: 'AdjP',
+	value: '(',
+	boundary_category: 'NP',
+}
+
+const default_advp: PageSourceEntity = {
+	...defaults,
+	category: 'Adverb Phrase',
+	category_abbr: 'AdvP',
+	value: '(',
+	boundary_category: 'NP',
+}
+
+export const DEFAULTS = {
+	EMPTY: defaults,
+	CLAUSE_MAIN: default_main_clause,
+	CLAUSE_SUBORDINATE: default_subordinate_clause,
+	CLAUSE_RELATIVE: default_relative_clause,
+	CLAUSE_PATIENT: default_patient_clause,
+	NOUN_PHRASE: default_np,
+	VERB_PHRASE: default_vp,
+	ADJECTIVE_PHRASE: default_adjp,
+	ADVERB_PHRASE: default_advp,
+}

--- a/src/lib/edit/default_entities.ts
+++ b/src/lib/edit/default_entities.ts
@@ -186,6 +186,20 @@ const default_phrasal: PageSourceEntity = {
 	concept: { stem: '', sense: '', part_of_speech: 'Phrasal' },
 }
 
+const default_period: PageSourceEntity = {
+	...defaults,
+	category: 'period',
+	category_abbr: 'period',
+	value: '.',
+}
+
+const default_paragraph: PageSourceEntity = {
+	...defaults,
+	category: 'Paragraph',
+	category_abbr: 'R',
+	value: '|',
+}
+
 export const DEFAULTS = {
 	EMPTY: defaults,
 	CLAUSE_MAIN: default_main_clause,
@@ -209,4 +223,6 @@ export const DEFAULTS = {
 	CONJUNCTION: default_conjunction,
 	PHRASAL: default_phrasal,
 	PARTICLE: default_particle,
+	PERIOD: default_period,
+	PARAGRAPH: default_paragraph,
 }

--- a/src/lib/edit/index.d.ts
+++ b/src/lib/edit/index.d.ts
@@ -1,5 +1,6 @@
 
 type EntityContextMenuData = {
+	is_open: boolean
 	entity_id: number
 	x: number
 	y: number

--- a/src/lib/encoding/features.ts
+++ b/src/lib/encoding/features.ts
@@ -114,15 +114,20 @@ function feature_structure_to_codes(category: CategoryName, features: EntityFeat
 	return codes.join('')
 }
 
+export function fill_in_features(source_entity: SourceEntity, all_features: FeatureMap): { feature_codes: string, features: EntityFeature[] } {
+	const { category, features } = source_entity
+	const feature_codes = feature_structure_to_codes(category, features, all_features)
+	// fill in any missing features in the structure
+	const new_features = feature_codes_to_structure(category, feature_codes, all_features)
+	return { feature_codes, features: new_features }
+}
+
 export async function transform_features_to_codes(db: D1Database, source_entities: SourceEntity[]): Promise<SourceEntity[]> {
 	const all_features = await load_source_feature_map(db)
 
 	return source_entities.map(entity => {
-		const { category, features } = entity
-		const feature_codes = feature_structure_to_codes(category, features, all_features)
-		// fill in any missing features in the structure
-		const new_features = feature_codes_to_structure(category, feature_codes, all_features)
-		return { ...entity, feature_codes, features: new_features }
+		const { feature_codes, features } =	fill_in_features(entity, all_features)
+		return { ...entity, feature_codes, features }
 	})
 }
 

--- a/src/lib/encoding/semantic_encoding.ts
+++ b/src/lib/encoding/semantic_encoding.ts
@@ -35,7 +35,7 @@ export async function transform_semantic_encoding(db: D1Database, semantic_encod
 	function decode_entity(entity_match: RegExpMatchArray): SourceEntity {
 		const category_code = entity_match[1] ?? ''
 		const feature_codes = entity_match[2] ?? ''
-		const value = entity_match[3]
+		const value = entity_match[3] === 'Paragraph' ? '|' : entity_match[3]
 
 		const category = CATEGORY_NAME_LOOKUP.get(category_code) || ''
 		const category_abbr = CATEGORY_ABBREVIATIONS.get(category) || ''
@@ -73,7 +73,7 @@ export async function transform_target_encoding(db: D1Database, semantic_encodin
 
 		const value = entity_match[2]
 		const concept = decode_concept_data(value, category, raw_feature_codes).concept
-		const target = entity_match[3] || ''
+		const target = entity_match[3] === 'Paragraph' ? '|' : entity_match[3] || ''
 
 		return {
 			category,

--- a/src/lib/entity_displays/BoundaryStart.svelte
+++ b/src/lib/entity_displays/BoundaryStart.svelte
@@ -10,8 +10,8 @@
 	let bracket_entity = $derived({ ...source_entity, value: '[' })
 </script>
 
-<div class="inline-flex items-center pe-2 entity-{source_entity.boundary_category}">
-	<Punctuation source_entity={bracket_entity} classes={source_entity.value === '{' ? 'text-7xl' : ''} />
+<div class="inline-flex items-center entity-{source_entity.boundary_category}">
+	<Punctuation source_entity={bracket_entity} classes="pe-1 {source_entity.value === '{' ? 'text-7xl' : ''}" />
 	<HoverPopup>
 		{#snippet button_content()}
 			<span class="font-semibold -ms-1">{source_entity.category_abbr}{feature_code_display}</span>

--- a/src/lib/entity_displays/Punctuation.svelte
+++ b/src/lib/entity_displays/Punctuation.svelte
@@ -3,6 +3,6 @@
 	let { source_entity, classes='' } = $props()
 </script>
 
-<span class="px-1 -mt-4 text-6xl font-thin {classes}">
-	{source_entity.category === 'Paragraph' || source_entity.value === 'Paragraph' ? '¶' : source_entity.value}
+<span class="-mt-4 text-6xl font-thin {classes}">
+	{source_entity.category === 'Paragraph' ? '¶' : source_entity.value}
 </span>

--- a/src/lib/entity_displays/SourceEntities.svelte
+++ b/src/lib/entity_displays/SourceEntities.svelte
@@ -82,7 +82,7 @@
 	{#each source_entities as entity}
 		{@const i = entity.id}
 		{@const Component = component_filters.find(([filter]) => filter(entity))?.[1]}
-		<div bind:this={entity_divs[i]} role="button" tabindex="0" class="cursor-pointer content-center h-20 {entity_highlights[i]}"
+		<div bind:this={entity_divs[i]} role="button" tabindex="0" class="cursor-pointer content-center px-1 h-20 {entity_highlights[i]}"
 				onclick={() => entity_focus(i)}
 				onkeydown={e => (e.key === 'Enter' || e.key === ' ') && entity_focus(i)}
 				onmouseenter={() => entity_mouseover(i)}

--- a/src/lib/entity_displays/SourceEntities.svelte
+++ b/src/lib/entity_displays/SourceEntities.svelte
@@ -83,8 +83,7 @@
 		{@const i = entity.id}
 		{@const Component = component_filters.find(([filter]) => filter(entity))?.[1]}
 		<div bind:this={entity_divs[i]} role="button" tabindex="0" class="cursor-pointer content-center px-1 h-20 {entity_highlights[i]}"
-				onclick={() => entity_focus(i)}
-				onkeydown={e => (e.key === 'Enter' || e.key === ' ') && entity_focus(i)}
+				onkeydown={e => e.key === 'Enter' && entity_focus(i)}
 				onmouseenter={() => entity_mouseover(i)}
 				onfocus={() => entity_focus(i)}
 				onmouseleave={entity_mouseout}

--- a/src/lib/sidebar/SidebarEntityDisplay.svelte
+++ b/src/lib/sidebar/SidebarEntityDisplay.svelte
@@ -35,5 +35,7 @@
 				{/if}
 			</div>
 		</div>
+	{:else}
+		<Punctuation source_entity={entity} />
 	{/if}
 </div>

--- a/src/lib/sidebar_edit/FeaturesDetails.svelte
+++ b/src/lib/sidebar_edit/FeaturesDetails.svelte
@@ -1,11 +1,11 @@
-<script>
+<script lang="ts">
 	import { is_used_in_source } from '$lib/encoding/features'
+	import { page } from '$app/state'
 
-	/** @type {{ data: PageSourceEntity, all_features: FeatureMap }} */
-	const { data = $bindable(), all_features } = $props()
+	const { data = $bindable() }: { data: PageSourceEntity } = $props()
 
 	let filtered_features = $derived(data.features.filter(is_used_in_source(data.category)))
-	let category_features = $derived(all_features.get(data.category) ?? [])
+	let category_features = $derived((page.data.features as FeatureMap).get(data.category) ?? [])
 
 	$effect(() => {
 		if (data.category === 'Noun Phrase') {
@@ -19,14 +19,6 @@
 			}
 		}
 	})
-
-	/**
-	 * @param {EntityFeature} feature
-	 * @returns {boolean}
-	 */
-	function can_be_dulled({ value }) {
-		return value === 'No' || ['Un', 'No ', 'Not '].some(prefix => value.startsWith(prefix))
-	}
 </script>
 
 {#if filtered_features.length === 0}
@@ -37,7 +29,7 @@
 			{#each data.features as feature}
 				{#if is_used_in_source(data.category)(feature)}
 					{@const possible_values = category_features.find(f => f.name === feature.name)?.values || []}
-					<tr class="{can_be_dulled(feature) ? 'opacity-50' : ''}">
+					<tr>
 						<td class="w-2/5">{feature.name}</td>
 						<td class="w-3/5">
 							<select bind:value={feature.value} class="select select-sm">

--- a/src/lib/sidebar_edit/NounListDetails.svelte
+++ b/src/lib/sidebar_edit/NounListDetails.svelte
@@ -1,6 +1,6 @@
 <script>
 	/** @type {{ data: PageSourceEntity, noun_list: NounListEntry[] }}*/
-	const { data = $bindable(), noun_list } = $props()
+	const { data = $bindable(), noun_list = $bindable() } = $props()
 
 	const next_index = $derived(calculate_next_index())
 

--- a/src/lib/sidebar_edit/Sidebar.svelte
+++ b/src/lib/sidebar_edit/Sidebar.svelte
@@ -15,7 +15,9 @@
 	let { entity = $bindable(), onclose, noun_list = $bindable() }: Props = $props()
 </script>
 
-<div class="fixed top-0 right-0 h-full w-100 bg-base-100 border-l border-base-300 shadow-xl flex flex-col">
+<svelte:window onkeydown={e => e.key === 'Escape' && onclose()} />
+
+<div class="fixed top-0 right-0 h-full w-96 bg-base-100 border-l border-base-300 shadow-xl flex flex-col">
 	<button class="btn btn-circle btn-ghost btn-sm absolute right-3 top-5" onclick={onclose} >
 		<Icon icon="material-symbols:close" class="h-4 w-4" />
 	</button>

--- a/src/lib/sidebar_edit/Sidebar.svelte
+++ b/src/lib/sidebar_edit/Sidebar.svelte
@@ -11,9 +11,8 @@
 		entity: PageSourceEntity|null
 		onclose: () => void
 		noun_list: NounListEntry[]
-		all_features: FeatureMap
 	}
-	let { entity = $bindable(), onclose, noun_list, all_features }: Props = $props()
+	let { entity = $bindable(), onclose, noun_list = $bindable() }: Props = $props()
 </script>
 
 <div class="fixed top-0 right-0 h-full w-100 bg-base-100 border-l border-base-300 shadow-xl flex flex-col">
@@ -63,7 +62,7 @@
 				{#if entity.category === 'Noun'}
 					<SidebarDetail summary_title="Noun List Index">
 						{#snippet details_content()}
-							<NounListDetails bind:data={entity!} {noun_list} />
+							<NounListDetails bind:data={entity!} bind:noun_list={noun_list} />
 						{/snippet}
 					</SidebarDetail>
 				{/if}
@@ -72,7 +71,7 @@
 				{#if entity.features.length > 0}
 					<SidebarDetail summary_title="Features" start_open={true}>
 						{#snippet details_content()}
-							<FeaturesDetails bind:data={entity!} {all_features}/>
+							<FeaturesDetails bind:data={entity!} />
 						{/snippet}
 					</SidebarDetail>
 				{/if}

--- a/src/routes/[type]/[id_primary]/[id_secondary]/[id_tertiary]/edit/+page.svelte
+++ b/src/routes/[type]/[id_primary]/[id_secondary]/[id_tertiary]/edit/+page.svelte
@@ -12,7 +12,6 @@
 	let phase1_text = $state('')
 	let source_entities = $state<PageSourceEntity[]>([])
 	let noun_list = $state<NounListEntry[]>([])
-	let all_features = $derived(data.features)
 
 	$effect(() => {
 		phase1_text = data.source.phase_1_encoding
@@ -22,8 +21,8 @@
 
 	let is_checked = $state(false)
 	let checking = $state(false)
-	let check_result: CheckerResult|null = $state(null)
-	let errors_and_warnings: [CheckerMessage, number][] = $state([])
+	let check_result = $state<CheckerResult | null>(null)
+	let errors_and_warnings = $state<[CheckerMessage, number][]>([])
 
 	let analyzing = $state(false)
 	let api_error = $state<string | null>(null)
@@ -196,10 +195,10 @@
 	<div class="divider my-2"></div>
 	<div class="flex h-screen">
 		<div class="overflow-y-auto transition-all duration-300 flex-[1_1_auto]" style="margin-right: {sidebar_open ? '24rem' : '0'};">
-			<SourceEntitiesEdit bind:source_entities={source_entities} {selected_entity} {on_entity_select} />
+			<SourceEntitiesEdit bind:source_entities {selected_entity} {on_entity_select} />
 		</div>
 		{#if sidebar_open}
-			<Sidebar bind:entity={selected_entity} onclose={on_sidebar_close} {noun_list} {all_features} />
+			<Sidebar bind:entity={selected_entity} onclose={on_sidebar_close} bind:noun_list />
 		{/if}
 	</div>
 {/if}


### PR DESCRIPTION
Add an insert button between the entities to be able to insert a new entity - clause, phrase, or concept.

<img width="1406" height="659" alt="image" src="https://github.com/user-attachments/assets/45900975-d477-46dc-8075-44e4a16ad1c2" />

A couple things I'm unsure about:
- the gap between entities due to the insert button. I tried to make it as small as I could, but it still feels too big. I thought about having there be no gap until the mouse comes close, but that feels too complicated and there would be too much wiggling around.
- the left-click to open the insert context menu, and right-click to open the entity context menu. That feels unintuitive. Should we make it so that left-clicking on the entity opens the sidebar _and_ opens the context menu?

Play around with it a bit and let me know what you think